### PR TITLE
Implement basic CI flow

### DIFF
--- a/.github/verible.waiver
+++ b/.github/verible.waiver
@@ -1,0 +1,9 @@
+# Copyright 2022 ETH Zurich and University of Bologna.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Auto-generated configuration registers are waived
+waive --rule=typedef-structs-unions --location="hw/regs/*"
+waive --rule=line-length --location="hw/regs/*"
+waive --rule=no-trailing-spaces --location="hw/regs/*"
+waive --rule=parameter-name-style --location="hw/regs/*"

--- a/.github/workflows/gitlab-ci.yml
+++ b/.github/workflows/gitlab-ci.yml
@@ -1,0 +1,22 @@
+# Copyright 2022 ETH Zurich and University of Bologna.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Author: Sergio Mazzola <smazzola@iis.ee.ethz.ch>
+
+name: gitlab-ci
+
+on: [ push, pull_request, workflow_dispatch ]
+
+jobs:
+  gitlab-ci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Gitlab CI
+        uses: pulp-platform/pulp-actions/gitlab-ci@v2
+        # Skip on forks or pull requests from forks due to missing secrets.
+        if: github.repository == 'pulp-platform/chimera' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        with:
+          domain: iis-git.ee.ethz.ch
+          repo: github-mirror/chimera
+          token: ${{ secrets.GITLAB_TOKEN }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,70 @@
+# Copyright 2022 ETH Zurich and University of Bologna.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Author: Sergio Mazzola <smazzola@iis.ee.ethz.ch>
+
+name: lint
+
+on: [ push, pull_request, workflow_dispatch ]
+
+jobs:
+
+  lint-license:
+    runs-on: ubuntu-latest
+    steps:
+    -
+      name: Checkout
+      uses: actions/checkout@v3
+    -
+      name: Check license
+      uses: pulp-platform/pulp-actions/lint-license@v2
+      with:
+        license: |
+          Copyright (\d{4}(-\d{4})?\s)?.*
+          (Solderpad Hardware License, Version 0.51|Licensed under the Apache License, Version 2.0), see LICENSE for details.
+          SPDX-License-Identifier: (SHL-0.51|Apache-2.0)
+        exclude_paths: |
+          utils/*
+        # sw/include/regs/*.h
+
+  lint-sv:
+    runs-on: ubuntu-latest
+    steps:
+    -
+      name: Checkout
+      uses: actions/checkout@v3
+    -
+      name: Run Verible
+      uses: chipsalliance/verible-linter-action@main
+      with:
+        paths: hw
+        extra_args: "--waiver_files .github/verible.waiver"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        fail_on_error: true
+        reviewdog_reporter: github-check
+
+  lint-cxx:
+    runs-on: ubuntu-latest
+    steps:
+    -
+      name: Checkout
+      uses: actions/checkout@v3
+    -
+      name: Run Clang-format
+      uses: DoozyX/clang-format-lint-action@v0.14
+      with:
+        extensions: 'c,h,cpp'
+        clangFormatVersion: 14
+        style: >
+          {
+          IndentWidth: 4,
+          ColumnLimit: 100,
+          AlignEscapedNewlines: DontAlign,
+          SortIncludes: false,
+          AllowShortFunctionsOnASingleLine: None,
+          AllowShortIfStatementsOnASingleLine: true,
+          AllowShortLoopsOnASingleLine: true
+          }
+        exclude: |
+          ./sw/include/regs/*.h

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .bender
+.venv
 
 # EMACS
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,82 @@
+# Copyright 2022 ETH Zurich and University of Bologna.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Author: Sergio Mazzola <smazzola@iis.ee.ethz.ch>
+
+variables:
+  # Enable colors in CI terminal
+  TERM: ansi
+  FORCE_COLOR: 1
+  # Toolchain
+  QUESTA_SEPP: questa-2022.3
+  VSIM: $QUESTA_SEPP vsim
+  RISCV_GCC_BINROOT: /usr/pack/riscv-1.0-kgf/pulp-gcc-2.5.0/bin
+  CC: /usr/pack/gcc-11.2.0-af/linux-x64/bin/gcc
+  CXX: /usr/pack/gcc-11.2.0-af/linux-x64/bin/g++
+  PYTHON: /usr/local/anaconda3-2022.05/bin/python3
+  CMAKE: cmake-3.28.3
+
+before_script:
+  # Set up environment
+  - export PATH=$RISCV_GCC_BINROOT:$PATH
+  - if [ -d .venv ]; then source .venv/bin/activate; fi
+  # Check environment variables
+  - env
+
+stages:
+  - setup
+  - build
+  - test
+
+.base:
+  artifacts:
+    when: always
+    expire_in: 1 week
+
+setup-env:
+  extends: .base
+  stage: setup
+  script:
+    # Install python virtual environment
+    - $PYTHON -m venv .venv
+    - source .venv/bin/activate
+    - python3 -m pip install --upgrade pip
+    - python3 -m pip install -r requirements.txt
+  artifacts:
+    paths: [ ".venv" ]
+
+vsim-build:
+  extends: .base
+  stage: build
+  needs: [ setup-env ]
+  script:
+    # Checkout dependencies
+    - bender checkout
+    # Build hardware
+    - make chs-hw-init
+    - make snitch-hw-init
+    - make chs-sim-all
+    - make chim-sim
+    # Compile software
+    - make chim-sw
+    # Compile SoC in vsim
+    - cd target/sim/vsim
+    - $VSIM -c -do 'quit -code [source compile.tcl]'
+  dependencies:
+    - setup-env
+  artifacts:
+    paths: [ ".venv", "hw", "sw", "target/sim" ]
+
+vsim-test:
+  extends: .base
+  stage: test
+  needs: [ vsim-build ]
+  script:
+    - cd target/sim/vsim
+    - $VSIM -c -do 'source setup.chimera_soc.tcl; source start.chimera_soc.tcl; run -all'
+    - ../../../scripts/vsim_ret_error.sh transcript
+  dependencies:
+    - vsim-build
+  artifacts:
+    paths: [ ".venv", "hw", "sw", "target/sim" ]

--- a/scripts/vsim_ret_error.sh
+++ b/scripts/vsim_ret_error.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 ETH Zurich and University of Bologna.
+# Solderpad Hardware License, Version 0.51, see LICENSE for details.
+# SPDX-License-Identifier: SHL-0.51
+
+# Author: Sergio Mazzola, ETH Zurich
+
+# Parse the number of errors from the last occurrence in the transcript
+RET=$(grep -Po '(?<=Errors: )\d+' "$1" | tail -n 1)
+# Check if pattern not found
+[[ -z "${RET}" ]] && echo "Simulation did not finish or no errors found" && exit 1
+
+# Return with the number of errors
+echo "Simulation returned ${RET} errors"
+[[ "${RET}" -eq 0 ]] && exit 0 || exit 1

--- a/target/sim/vsim/start.chimera_soc.tcl
+++ b/target/sim/vsim/start.chimera_soc.tcl
@@ -24,7 +24,9 @@ if {[info exists PRELMODE]} { append pargs "+PRELMODE=${PRELMODE} " }
 if {[info exists BINARY]}   { append pargs "+BINARY=${BINARY} " }
 if {[info exists IMAGE]}    { append pargs "+IMAGE=${IMAGE} " }
 
-eval "vsim -c ${TESTBENCH} -t 1ps -vopt -voptargs=\"${VOPTARGS}\"" ${pargs} ${flags}
+if {[catch {
+    eval "vsim -c ${TESTBENCH} -t 1ps -vopt -voptargs=\"${VOPTARGS}\"" ${pargs} ${flags}
+}]} {return 1}
 
 set StdArithNoWarnings 1
 set NumericStdNoWarnings 1


### PR DESCRIPTION
This PR implements a basic CI flow divided (for now) in 2 workflows (`.github/workflows`):
- a workflow for public actions, taking care of linting for license headers, SystemVerilog codestyle, and C codestyle
- a workflow triggering runners on our internal GitLab, for regression tests using proprietary tools

The jobs executed by our internal runners are described in `.gitlab-ci.yml`.
For now, the hardware is built using QuestaSim and a basic test is executed.

CI failure is currently expected both for linting and regression test.
Next steps:

- [ ] extend with more advanced test strategy
- [ ] fix license headers and codestyle
- [ ] `buildroot` module, cloned by the `cva6-sdk` (in turn, used by the Cheshire dependency), sometimes cannot be cloned and causes the CI to randomly fail; I believe we can remove the dependency to the `cva6-sdk` from our custom branch of Cheshire