### PR TITLE
Add support for multiple parallel functional regression test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ modelsim.ini
 compile.tcl
 logs
 vsim.wlf
+*.transcript

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -72,11 +72,15 @@ vsim-test:
   extends: .base
   stage: test
   needs: [ vsim-build ]
+  parallel:
+    matrix:
+      - TESTNAME: [testCluster, testClusterOffload]
   script:
     - cd target/sim/vsim
-    - $VSIM -c -do 'source setup.chimera_soc.tcl; source start.chimera_soc.tcl; run -all'
-    - ../../../scripts/vsim_ret_error.sh transcript
+    - $VSIM -c -l $TESTNAME.transcript -do "set BINARY ../../../sw/tests/$TESTNAME.memisl.elf; source start.chimera_soc.tcl; run -all"
+    - ../../../scripts/vsim_ret_error.sh $TESTNAME.transcript
   dependencies:
     - vsim-build
   artifacts:
-    paths: [ ".venv", "hw", "sw", "target/sim" ]
+    paths: [ ".venv", "hw", "sw", "target/sim", "$TESTNAME.transcript" ]
+    expire_in: 4 weeks


### PR DESCRIPTION
This PR adds support to run multiple regression tests in parallel 

## Added
* Support to run more than one regression test in CI

## Changed
* vsim now outputs one transcript per test
* Each transcript is stored as an artifact
* Artifacts are kept for up to 4 weeks 