### PR TITLE
Add support for 32 AXI Data & Address width

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -166,8 +166,8 @@ packages:
     dependencies:
     - common_cells
   idma:
-    revision: c12caf59bb482fe44b27361f6924ad346b2d22fe
-    version: 0.6.3
+    revision: 9edf489f57389dce5e71252c79e337f527d3aded
+    version: null
     source:
       Git: https://github.com/pulp-platform/iDMA.git
     dependencies:

--- a/Bender.yml
+++ b/Bender.yml
@@ -13,16 +13,19 @@ dependencies:
   cheshire:                 { git: "https://github.com/pulp-platform/cheshire.git",           rev: 4dfba37385eae48c44080defdfaa3f580921a60c}
   snitch_cluster:           { git: "https://github.com/pulp-platform/snitch_cluster.git",     rev: c12ce9b2af1ac8edf3d4feb18939e1ad20c42225}
   common_cells:             { git: "https://github.com/pulp-platform/common_cells.git",       version: 1.31.1}
+  idma:                     { git: "https://github.com/pulp-platform/iDMA.git",               rev: 9edf489f57389dce5e71252c79e337f527d3aded}
 
 workspace:
   package_links:
     cheshire: cheshire
+    idma: idma
 
 sources:
   - hw/chimera_pkg.sv
   - hw/regs/chimera_reg_pkg.sv
   - hw/regs/chimera_reg_top.sv
   - hw/bootrom/snitch/snitch_bootrom.sv
+  - hw/narrow_adapter.sv
   - hw/chimera_cluster_adapter.sv
   - hw/chimera_top_wrapper.sv
 

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ BENDER   ?= bender -d $(CHIM_ROOT)
 
 CHS_ROOT      ?= $(shell $(BENDER) path cheshire)
 SNITCH_ROOT      ?= $(shell $(BENDER) path snitch_cluster)
+IDMA_ROOT      ?= $(shell $(BENDER) path idma)
 CHS_XLEN ?= 32
 
 CHIM_HW_DIR      ?= $(CHIM_ROOT)/hw

--- a/chimera.mk
+++ b/chimera.mk
@@ -4,7 +4,7 @@
 #
 # Moritz Scherer <scheremo@iis.ee.ethz.ch>
 
-CLINTCORES = 46 
+CLINTCORES = 46
 PLICCORES = 92
 PLIC_NUM_INTRS = 92
 
@@ -13,8 +13,11 @@ update_plic: $(CHS_ROOT)/hw/rv_plic.cfg.hjson
 	sed -i 's/src: .*/src: $(PLIC_NUM_INTRS),/' $<
 	sed -i 's/target: .*/target: $(PLICCORES),/' $<
 
+gen_idma_hw:
+	make -C $(IDMA_ROOT) idma_hw_all
+
 .PHONY: chs-hw-init
-chs-hw-init: update_plic
+chs-hw-init: update_plic gen_idma_hw
 	make -B chs-hw-all CHS_XLEN=$(CHS_XLEN)
 
 .PHONY: snitch-hw-init

--- a/chimera.mk
+++ b/chimera.mk
@@ -13,6 +13,7 @@ update_plic: $(CHS_ROOT)/hw/rv_plic.cfg.hjson
 	sed -i 's/src: .*/src: $(PLIC_NUM_INTRS),/' $<
 	sed -i 's/target: .*/target: $(PLICCORES),/' $<
 
+# SCHEREMO: Technically, there exists a __deploy__* tag for the idma with fixes, but we're checking out the base version
 gen_idma_hw:
 	make -C $(IDMA_ROOT) idma_hw_all
 

--- a/hw/chimera_pkg.sv
+++ b/hw/chimera_pkg.sv
@@ -37,6 +37,8 @@ package chimera_pkg;
 
   // SCHEREMO: Shared Snitch bootrom, one clock gate per cluster
   localparam int ExtRegNum = SnitchBootROM + 1;
+  localparam int ClusterDataWidth = 64;
+
 
   localparam int SnitchBootROMIdx = 0;
   localparam doub_bt SnitchBootROMRegionStart = 64'h3000_0000;
@@ -66,6 +68,9 @@ package chimera_pkg;
     // AXI CFG
     // SCHEREMO: Assume 2 Master per cluster -> 5 clusters, 1 host core, 1 DMA, 1 DBG Unit
     cfg.AxiMstIdWidth = 4;
+    cfg.AxiDataWidth = 32;
+    cfg.AddrWidth = 32;
+    cfg.LlcOutRegionEnd = 'hFFFF_FFFF;
 
     cfg.MemIslWidePorts = $countones(ChimeraClusterCfg.hasWideMasterPort);
     cfg.AxiExtNumWideMst = $countones(ChimeraClusterCfg.hasWideMasterPort);

--- a/hw/chimera_top_wrapper.sv
+++ b/hw/chimera_top_wrapper.sv
@@ -341,20 +341,19 @@ module chimera_top_wrapper
                    axi_cluster_mst_id_width_narrow_t, axi_soc_data_narrow_t, axi_soc_strb_narrow_t,
                    axi_cluster_user_t)
 
+  // Cluster-side in- and out- narrow ports used in chimera adapter
+  axi_cluster_in_narrow_req_t       [iomsb(Cfg.AxiExtNumSlv):0] clu_axi_adapter_slv_req;
+  axi_cluster_in_narrow_resp_t      [iomsb(Cfg.AxiExtNumSlv):0] clu_axi_adapter_slv_resp;
+  axi_cluster_soc_out_narrow_req_t  [iomsb(Cfg.AxiExtNumMst):0] clu_axi_adapter_mst_req;
+  axi_cluster_soc_out_narrow_resp_t [iomsb(Cfg.AxiExtNumMst):0] clu_axi_adapter_mst_resp;
 
+  // Cluster-side in- and out- narrow ports used in narrow adapter
+  axi_cluster_in_narrow_req_t       [iomsb(Cfg.AxiExtNumSlv):0] clu_axi_narrow_slv_req;
+  axi_cluster_in_narrow_resp_t      [iomsb(Cfg.AxiExtNumSlv):0] clu_axi_narrow_slv_rsp;
+  axi_cluster_out_narrow_req_t      [iomsb(Cfg.AxiExtNumMst):0] clu_axi_narrow_mst_req;
+  axi_cluster_out_narrow_resp_t     [iomsb(Cfg.AxiExtNumMst):0] clu_axi_narrow_mst_rsp;
 
-  axi_cluster_in_narrow_req_t       [iomsb(Cfg.AxiExtNumSlv):0] clu_axi_slv_req;
-  axi_cluster_in_narrow_resp_t      [iomsb(Cfg.AxiExtNumSlv):0] clu_axi_slv_resp;
-
-  axi_cluster_soc_out_narrow_req_t  [iomsb(Cfg.AxiExtNumMst):0] clu_axi_mst_req;
-  axi_cluster_soc_out_narrow_resp_t [iomsb(Cfg.AxiExtNumMst):0] clu_axi_mst_resp;
-
-  axi_cluster_in_narrow_req_t       [iomsb(Cfg.AxiExtNumSlv):0] clu_64_axi_slv_req;
-  axi_cluster_in_narrow_resp_t      [iomsb(Cfg.AxiExtNumSlv):0] clu_64_axi_slv_rsp;
-
-  axi_cluster_out_narrow_req_t      [iomsb(Cfg.AxiExtNumMst):0] clu_64_axi_mst_req;
-  axi_cluster_out_narrow_resp_t     [iomsb(Cfg.AxiExtNumMst):0] clu_64_axi_mst_rsp;
-
+  // Cluster-side out wide ports
   axi_cluster_out_wide_req_t        [     iomsb(ExtClusters):0] clu_axi_wide_mst_req;
   axi_cluster_out_wide_resp_t       [     iomsb(ExtClusters):0] clu_axi_wide_mst_resp;
 
@@ -393,25 +392,27 @@ module chimera_top_wrapper
           .soc_clk_i(soc_clk_i),
           .rst_ni,
 
+          // SoC side narrow.
           .narrow_in_req_i  (axi_slv_req[extClusterIdx]),
           .narrow_in_resp_o (axi_slv_rsp[extClusterIdx]),
           .narrow_out_req_o (axi_mst_req[2*extClusterIdx+:2]),
           .narrow_out_resp_i(axi_mst_rsp[2*extClusterIdx+:2]),
 
-          .clu_narrow_in_req_o  (clu_64_axi_slv_req[extClusterIdx]),
-          .clu_narrow_in_resp_i (clu_64_axi_slv_rsp[extClusterIdx]),
-          .clu_narrow_out_req_i (clu_64_axi_mst_req[2*extClusterIdx+:2]),
-          .clu_narrow_out_resp_o(clu_64_axi_mst_rsp[2*extClusterIdx+:2])
+          // Cluster side narrow
+          .clu_narrow_in_req_o  (clu_axi_narrow_slv_req[extClusterIdx]),
+          .clu_narrow_in_resp_i (clu_axi_narrow_slv_rsp[extClusterIdx]),
+          .clu_narrow_out_req_i (clu_axi_narrow_mst_req[2*extClusterIdx+:2]),
+          .clu_narrow_out_resp_o(clu_axi_narrow_mst_rsp[2*extClusterIdx+:2])
 
         );
 
 
       end else begin : gen_skip_narrow_adapter  // if (ClusterDataWidth != Cfg.AxiDataWidth)
 
-        assign clu_64_axi_slv_req = axi_slv_req;
-        assign clu_64_axi_slv_rsp = axi_slv_rsp;
-        assign clu_64_axi_mst_req = axi_mst_req;
-        assign clu_64_axi_mst_rsp = axi_mst_rsp;
+        assign clu_axi_narrow_slv_req = axi_slv_req;
+        assign clu_axi_narrow_slv_rsp = axi_slv_rsp;
+        assign clu_axi_narrow_mst_req = axi_mst_req;
+        assign clu_axi_narrow_mst_rsp = axi_mst_rsp;
 
       end
 
@@ -443,16 +444,15 @@ module chimera_top_wrapper
         .clu_clk_i(clu_clk_gated[extClusterIdx]),
         .rst_ni,
 
-        .narrow_in_req_i  (clu_64_axi_slv_req[extClusterIdx]),
-        .narrow_in_resp_o (clu_64_axi_slv_rsp[extClusterIdx]),
-        .narrow_out_req_o (clu_64_axi_mst_req[2*extClusterIdx+:2]),
-        .narrow_out_resp_i(clu_64_axi_mst_rsp[2*extClusterIdx+:2]),
+        .narrow_in_req_i  (clu_axi_narrow_slv_req[extClusterIdx]),
+        .narrow_in_resp_o (clu_axi_narrow_slv_rsp[extClusterIdx]),
+        .narrow_out_req_o (clu_axi_narrow_mst_req[2*extClusterIdx+:2]),
+        .narrow_out_resp_i(clu_axi_narrow_mst_rsp[2*extClusterIdx+:2]),
 
-        .clu_narrow_in_req_o  (clu_axi_slv_req[extClusterIdx]),
-        .clu_narrow_in_resp_i (clu_axi_slv_resp[extClusterIdx]),
-        .clu_narrow_out_req_i (clu_axi_mst_req[extClusterIdx]),
-        .clu_narrow_out_resp_o(clu_axi_mst_resp[extClusterIdx]),
-
+        .clu_narrow_in_req_o  (clu_axi_adapter_slv_req[extClusterIdx]),
+        .clu_narrow_in_resp_i (clu_axi_adapter_slv_resp[extClusterIdx]),
+        .clu_narrow_out_req_i (clu_axi_adapter_mst_req[extClusterIdx]),
+        .clu_narrow_out_resp_o(clu_axi_adapter_mst_resp[extClusterIdx]),
 
         .wide_out_req_o     (axi_wide_mst_req[extClusterIdx]),
         .wide_out_resp_i    (axi_wide_mst_rsp[extClusterIdx]),
@@ -549,10 +549,10 @@ module chimera_top_wrapper
         .cluster_base_addr_i(Cfg.AxiExtRegionStart[extClusterIdx][Cfg.AddrWidth-1:0]),
         .sram_cfgs_i        ('0),
 
-        .narrow_in_req_i  (clu_axi_slv_req[extClusterIdx]),
-        .narrow_in_resp_o (clu_axi_slv_resp[extClusterIdx]),
-        .narrow_out_req_o (clu_axi_mst_req[extClusterIdx]),
-        .narrow_out_resp_i(clu_axi_mst_resp[extClusterIdx]),
+        .narrow_in_req_i  (clu_axi_adapter_slv_req[extClusterIdx]),
+        .narrow_in_resp_o (clu_axi_adapter_slv_resp[extClusterIdx]),
+        .narrow_out_req_o (clu_axi_adapter_mst_req[extClusterIdx]),
+        .narrow_out_resp_i(clu_axi_adapter_mst_resp[extClusterIdx]),
         .wide_in_req_i    ('0),
         .wide_in_resp_o   (),
         .wide_out_req_o   (clu_axi_wide_mst_req[extClusterIdx]),

--- a/hw/chimera_top_wrapper.sv
+++ b/hw/chimera_top_wrapper.sv
@@ -11,59 +11,48 @@ module chimera_top_wrapper
 #(
   parameter int unsigned SelectedCfg = 0
 ) (
-  input  logic                                            soc_clk_i,
-  input  logic                                            clu_clk_i,
-  input  logic                                            rst_ni,
-  input  logic                                            test_mode_i,
-  input  logic [                  1:0]                    boot_mode_i,
-  input  logic                                            rtc_i,
+  input  logic                 soc_clk_i,
+  input  logic                 clu_clk_i,
+  input  logic                 rst_ni,
+  input  logic                 test_mode_i,
+  input  logic [          1:0] boot_mode_i,
+  input  logic                 rtc_i,
   // JTAG interface
-  input  logic                                            jtag_tck_i,
-  input  logic                                            jtag_trst_ni,
-  input  logic                                            jtag_tms_i,
-  input  logic                                            jtag_tdi_i,
-  output logic                                            jtag_tdo_o,
-  output logic                                            jtag_tdo_oe_o,
+  input  logic                 jtag_tck_i,
+  input  logic                 jtag_trst_ni,
+  input  logic                 jtag_tms_i,
+  input  logic                 jtag_tdi_i,
+  output logic                 jtag_tdo_o,
+  output logic                 jtag_tdo_oe_o,
   // UART interface
-  output logic                                            uart_tx_o,
-  input  logic                                            uart_rx_i,
+  output logic                 uart_tx_o,
+  input  logic                 uart_rx_i,
   // UART modem flow control
-  output logic                                            uart_rts_no,
-  output logic                                            uart_dtr_no,
-  input  logic                                            uart_cts_ni,
-  input  logic                                            uart_dsr_ni,
-  input  logic                                            uart_dcd_ni,
-  input  logic                                            uart_rin_ni,
+  output logic                 uart_rts_no,
+  output logic                 uart_dtr_no,
+  input  logic                 uart_cts_ni,
+  input  logic                 uart_dsr_ni,
+  input  logic                 uart_dcd_ni,
+  input  logic                 uart_rin_ni,
   // I2C interface
-  output logic                                            i2c_sda_o,
-  input  logic                                            i2c_sda_i,
-  output logic                                            i2c_sda_en_o,
-  output logic                                            i2c_scl_o,
-  input  logic                                            i2c_scl_i,
-  output logic                                            i2c_scl_en_o,
+  output logic                 i2c_sda_o,
+  input  logic                 i2c_sda_i,
+  output logic                 i2c_sda_en_o,
+  output logic                 i2c_scl_o,
+  input  logic                 i2c_scl_i,
+  output logic                 i2c_scl_en_o,
   // SPI host interface
-  output logic                                            spih_sck_o,
-  output logic                                            spih_sck_en_o,
-  output logic [        SpihNumCs-1:0]                    spih_csb_o,
-  output logic [        SpihNumCs-1:0]                    spih_csb_en_o,
-  output logic [                  3:0]                    spih_sd_o,
-  output logic [                  3:0]                    spih_sd_en_o,
-  input  logic [                  3:0]                    spih_sd_i,
+  output logic                 spih_sck_o,
+  output logic                 spih_sck_en_o,
+  output logic [SpihNumCs-1:0] spih_csb_o,
+  output logic [SpihNumCs-1:0] spih_csb_en_o,
+  output logic [          3:0] spih_sd_o,
+  output logic [          3:0] spih_sd_en_o,
+  input  logic [          3:0] spih_sd_i,
   // GPIO interface
-  input  logic [                 31:0]                    gpio_i,
-  output logic [                 31:0]                    gpio_o,
-  output logic [                 31:0]                    gpio_en_o,
-  // Serial link interface
-  input  logic [     SlinkNumChan-1:0]                    slink_rcv_clk_i,
-  output logic [     SlinkNumChan-1:0]                    slink_rcv_clk_o,
-  input  logic [     SlinkNumChan-1:0][SlinkNumLanes-1:0] slink_i,
-  output logic [     SlinkNumChan-1:0][SlinkNumLanes-1:0] slink_o,
-  // VGA interface
-  output logic                                            vga_hsync_o,
-  output logic                                            vga_vsync_o,
-  output logic [ Cfg.VgaRedWidth -1:0]                    vga_red_o,
-  output logic [Cfg.VgaGreenWidth-1:0]                    vga_green_o,
-  output logic [Cfg.VgaBlueWidth -1:0]                    vga_blue_o
+  input  logic [         31:0] gpio_i,
+  output logic [         31:0] gpio_o,
+  output logic [         31:0] gpio_en_o
 );
 
   `include "axi/typedef.svh"
@@ -188,16 +177,24 @@ module chimera_top_wrapper
     .gpio_o,
     .gpio_en_o,
     // Serial link interface
-    .slink_rcv_clk_i,
-    .slink_rcv_clk_o,
-    .slink_i,
-    .slink_o,
+    .slink_rcv_clk_i       ('0),
+    .slink_rcv_clk_o       (),
+    .slink_i               ('0),
+    .slink_o               (),
     // VGA interface
-    .vga_hsync_o,
-    .vga_vsync_o,
-    .vga_red_o,
-    .vga_green_o,
-    .vga_blue_o
+    .vga_hsync_o           (),
+    .vga_vsync_o           (),
+    .vga_red_o             (),
+    .vga_green_o           (),
+    .vga_blue_o            (),
+    .usb_clk_i             ('0),
+    .usb_rst_ni            ('1),
+    .usb_dm_i              ('0),
+    .usb_dm_o              (),
+    .usb_dm_oe_o           (),
+    .usb_dp_i              ('0),
+    .usb_dp_o              (),
+    .usb_dp_oe_o           ()
   );
 
   // TOP-LEVEL REG
@@ -303,13 +300,21 @@ module chimera_top_wrapper
 
   localparam int WideSlaveIdWidth = $bits(axi_wide_mst_req[0].aw.id);
   localparam int NarrowSlaveIdWidth = $bits(axi_slv_req[0].aw.id);
+  localparam int NarrowMasterIdWidth = $bits(axi_mst_req[0].aw.id);
 
   typedef logic [Cfg.AddrWidth-1:0] axi_cluster_addr_t;
   typedef logic [Cfg.AxiUserWidth-1:0] axi_cluster_user_t;
 
-  typedef logic [Cfg.AxiDataWidth-1:0] axi_cluster_data_narrow_t;
-  typedef logic [Cfg.AxiDataWidth/8-1:0] axi_cluster_strb_narrow_t;
+  typedef logic [Cfg.AxiDataWidth-1:0] axi_soc_data_narrow_t;
+  typedef logic [Cfg.AxiDataWidth/8-1:0] axi_soc_strb_narrow_t;
+
+  typedef logic [ClusterDataWidth-1:0] axi_cluster_data_narrow_t;
+  typedef logic [ClusterDataWidth/8-1:0] axi_cluster_strb_narrow_t;
+
   typedef logic [NarrowSlaveIdWidth +2 -1:0] axi_cluster_slv_id_width_narrow_t;
+  typedef logic [NarrowSlaveIdWidth -1:0] axi_cluster_mst_id_width_narrow_t;
+
+  typedef logic [NarrowMasterIdWidth -1:0] axi_soc_mst_id_width_narrow_t;
 
   typedef logic [WideDataWidth-1:0] axi_cluster_data_wide_t;
   typedef logic [WideDataWidth/8-1:0] axi_cluster_strb_wide_t;
@@ -317,18 +322,44 @@ module chimera_top_wrapper
 
   `AXI_TYPEDEF_ALL(axi_cluster_out_wide, axi_cluster_addr_t, axi_cluster_slv_id_width_wide_t,
                    axi_cluster_data_wide_t, axi_cluster_strb_wide_t, axi_cluster_user_t)
-  `AXI_TYPEDEF_ALL(axi_cluster_out_narrow, axi_cluster_addr_t, axi_cluster_slv_id_width_narrow_t,
+
+  `AXI_TYPEDEF_ALL(axi_cluster_soc_out_narrow, axi_cluster_addr_t,
+                   axi_cluster_slv_id_width_narrow_t, axi_cluster_data_narrow_t,
+                   axi_cluster_strb_narrow_t, axi_cluster_user_t)
+
+  `AXI_TYPEDEF_ALL(axi_cluster_out_narrow, axi_cluster_addr_t, axi_soc_mst_id_width_narrow_t,
                    axi_cluster_data_narrow_t, axi_cluster_strb_narrow_t, axi_cluster_user_t)
 
-  axi_slv_req_t                 [iomsb(ExtClusters):0] clu_axi_slv_req;
-  axi_slv_rsp_t                 [iomsb(ExtClusters):0] clu_axi_slv_resp;
-  axi_cluster_out_narrow_req_t  [iomsb(ExtClusters):0] clu_axi_mst_req;
-  axi_cluster_out_narrow_resp_t [iomsb(ExtClusters):0] clu_axi_mst_resp;
-  axi_cluster_out_wide_req_t    [iomsb(ExtClusters):0] clu_axi_wide_mst_req;
-  axi_cluster_out_wide_resp_t   [iomsb(ExtClusters):0] clu_axi_wide_mst_resp;
+  `AXI_TYPEDEF_ALL(axi_cluster_out_socside_narrow, axi_cluster_addr_t,
+                   axi_soc_mst_id_width_narrow_t, axi_soc_data_narrow_t, axi_soc_strb_narrow_t,
+                   axi_cluster_user_t)
+
+  `AXI_TYPEDEF_ALL(axi_cluster_in_narrow, axi_cluster_addr_t, axi_cluster_mst_id_width_narrow_t,
+                   axi_cluster_data_narrow_t, axi_cluster_strb_narrow_t, axi_cluster_user_t)
+
+  `AXI_TYPEDEF_ALL(axi_cluster_in_socside_narrow, axi_cluster_addr_t,
+                   axi_cluster_mst_id_width_narrow_t, axi_soc_data_narrow_t, axi_soc_strb_narrow_t,
+                   axi_cluster_user_t)
+
+
+
+  axi_cluster_in_narrow_req_t       [iomsb(Cfg.AxiExtNumSlv):0] clu_axi_slv_req;
+  axi_cluster_in_narrow_resp_t      [iomsb(Cfg.AxiExtNumSlv):0] clu_axi_slv_resp;
+
+  axi_cluster_soc_out_narrow_req_t  [iomsb(Cfg.AxiExtNumMst):0] clu_axi_mst_req;
+  axi_cluster_soc_out_narrow_resp_t [iomsb(Cfg.AxiExtNumMst):0] clu_axi_mst_resp;
+
+  axi_cluster_in_narrow_req_t       [iomsb(Cfg.AxiExtNumSlv):0] clu_64_axi_slv_req;
+  axi_cluster_in_narrow_resp_t      [iomsb(Cfg.AxiExtNumSlv):0] clu_64_axi_slv_rsp;
+
+  axi_cluster_out_narrow_req_t      [iomsb(Cfg.AxiExtNumMst):0] clu_64_axi_mst_req;
+  axi_cluster_out_narrow_resp_t     [iomsb(Cfg.AxiExtNumMst):0] clu_64_axi_mst_rsp;
+
+  axi_cluster_out_wide_req_t        [     iomsb(ExtClusters):0] clu_axi_wide_mst_req;
+  axi_cluster_out_wide_resp_t       [     iomsb(ExtClusters):0] clu_axi_wide_mst_resp;
 
   // Cluster Adapters
-  logic                         [     ExtClusters-1:0] wide_mem_bypass_mode;
+  logic                             [          ExtClusters-1:0] wide_mem_bypass_mode;
   assign wide_mem_bypass_mode = {
     reg2hw.wide_mem_cluster_5_bypass.q,
     reg2hw.wide_mem_cluster_4_bypass.q,
@@ -342,43 +373,91 @@ module chimera_top_wrapper
         extClusterIdx = 0; extClusterIdx < ExtClusters; extClusterIdx++
     ) begin : gen_clusters_adapters
 
+      if (ClusterDataWidth != Cfg.AxiDataWidth) begin : gen_narrow_adapter
+
+        narrow_adapter #(
+          .narrow_in_req_t  (axi_cluster_in_socside_narrow_req_t),
+          .narrow_in_resp_t (axi_cluster_in_socside_narrow_resp_t),
+          .narrow_out_req_t (axi_cluster_out_socside_narrow_req_t),
+          .narrow_out_resp_t(axi_cluster_out_socside_narrow_resp_t),
+
+          .clu_narrow_in_req_t  (axi_cluster_in_narrow_req_t),
+          .clu_narrow_in_resp_t (axi_cluster_in_narrow_resp_t),
+          .clu_narrow_out_req_t (axi_cluster_out_narrow_req_t),
+          .clu_narrow_out_resp_t(axi_cluster_out_narrow_resp_t),
+
+          .MstPorts(2),
+          .SlvPorts(1)
+
+        ) i_cluster_narrow_adapter (
+          .soc_clk_i(soc_clk_i),
+          .rst_ni,
+
+          .narrow_in_req_i  (axi_slv_req[extClusterIdx]),
+          .narrow_in_resp_o (axi_slv_rsp[extClusterIdx]),
+          .narrow_out_req_o (axi_mst_req[2*extClusterIdx+:2]),
+          .narrow_out_resp_i(axi_mst_rsp[2*extClusterIdx+:2]),
+
+          .clu_narrow_in_req_o  (clu_64_axi_slv_req[extClusterIdx]),
+          .clu_narrow_in_resp_i (clu_64_axi_slv_rsp[extClusterIdx]),
+          .clu_narrow_out_req_i (clu_64_axi_mst_req[2*extClusterIdx+:2]),
+          .clu_narrow_out_resp_o(clu_64_axi_mst_rsp[2*extClusterIdx+:2])
+
+        );
+
+
+      end else begin : gen_skip_narrow_adapter  // if (ClusterDataWidth != Cfg.AxiDataWidth)
+
+        assign clu_64_axi_slv_req = axi_slv_req;
+        assign clu_64_axi_slv_rsp = axi_slv_rsp;
+        assign clu_64_axi_mst_req = axi_mst_req;
+        assign clu_64_axi_mst_rsp = axi_mst_rsp;
+
+      end
+
+
       chimera_cluster_adapter #(
         .WideSlaveIdWidth(WideSlaveIdWidth),
 
         .WidePassThroughRegionStart(Cfg.MemIslRegionStart),
         .WidePassThroughRegionEnd  (Cfg.MemIslRegionEnd),
 
-        .narrow_in_req_t  (axi_slv_req_t),
-        .narrow_in_resp_t (axi_slv_rsp_t),
-        .wide_in_req_t    (axi_wide_slv_req_t),
-        .wide_in_resp_t   (axi_wide_slv_rsp_t),
-        .narrow_out_req_t (axi_mst_req_t),
-        .narrow_out_resp_t(axi_mst_rsp_t),
-        .wide_out_req_t   (axi_wide_mst_req_t),
-        .wide_out_resp_t  (axi_wide_mst_rsp_t),
+        .narrow_in_req_t  (axi_cluster_in_narrow_req_t),
+        .narrow_in_resp_t (axi_cluster_in_narrow_resp_t),
+        .narrow_out_req_t (axi_cluster_out_narrow_req_t),
+        .narrow_out_resp_t(axi_cluster_out_narrow_resp_t),
 
-        .clu_narrow_out_req_t (axi_cluster_out_narrow_req_t),
-        .clu_narrow_out_resp_t(axi_cluster_out_narrow_resp_t),
-        .clu_wide_out_req_t   (axi_cluster_out_wide_req_t),
-        .clu_wide_out_resp_t  (axi_cluster_out_wide_resp_t)
+        .clu_narrow_out_req_t (axi_cluster_soc_out_narrow_req_t),
+        .clu_narrow_out_resp_t(axi_cluster_soc_out_narrow_resp_t),
+
+        .wide_in_req_t  (axi_wide_slv_req_t),
+        .wide_in_resp_t (axi_wide_slv_rsp_t),
+        .wide_out_req_t (axi_wide_mst_req_t),
+        .wide_out_resp_t(axi_wide_mst_rsp_t),
+
+        .clu_wide_out_req_t (axi_cluster_out_wide_req_t),
+        .clu_wide_out_resp_t(axi_cluster_out_wide_resp_t)
+
       ) i_cluster_axi_adapter (
         .soc_clk_i(soc_clk_i),
         .clu_clk_i(clu_clk_gated[extClusterIdx]),
         .rst_ni,
 
-        .narrow_in_req_i  (axi_slv_req[extClusterIdx]),
-        .narrow_in_resp_o (axi_slv_rsp[extClusterIdx]),
-        .narrow_out_req_o (axi_mst_req[2*extClusterIdx+:2]),
-        .narrow_out_resp_i(axi_mst_rsp[2*extClusterIdx+:2]),
-        .wide_out_req_o   (axi_wide_mst_req[extClusterIdx]),
-        .wide_out_resp_i  (axi_wide_mst_rsp[extClusterIdx]),
+        .narrow_in_req_i  (clu_64_axi_slv_req[extClusterIdx]),
+        .narrow_in_resp_o (clu_64_axi_slv_rsp[extClusterIdx]),
+        .narrow_out_req_o (clu_64_axi_mst_req[2*extClusterIdx+:2]),
+        .narrow_out_resp_i(clu_64_axi_mst_rsp[2*extClusterIdx+:2]),
 
         .clu_narrow_in_req_o  (clu_axi_slv_req[extClusterIdx]),
         .clu_narrow_in_resp_i (clu_axi_slv_resp[extClusterIdx]),
         .clu_narrow_out_req_i (clu_axi_mst_req[extClusterIdx]),
         .clu_narrow_out_resp_o(clu_axi_mst_resp[extClusterIdx]),
-        .clu_wide_out_req_i   (clu_axi_wide_mst_req[extClusterIdx]),
-        .clu_wide_out_resp_o  (clu_axi_wide_mst_resp[extClusterIdx]),
+
+
+        .wide_out_req_o     (axi_wide_mst_req[extClusterIdx]),
+        .wide_out_resp_i    (axi_wide_mst_rsp[extClusterIdx]),
+        .clu_wide_out_req_i (clu_axi_wide_mst_req[extClusterIdx]),
+        .clu_wide_out_resp_o(clu_axi_wide_mst_resp[extClusterIdx]),
 
         .wide_mem_bypass_mode_i(wide_mem_bypass_mode[extClusterIdx])
       );
@@ -407,7 +486,7 @@ module chimera_top_wrapper
     for (extClusterIdx = 0; extClusterIdx < ExtClusters; extClusterIdx++) begin : gen_clusters
       snitch_cluster #(
         .PhysicalAddrWidth(Cfg.AddrWidth),
-        .NarrowDataWidth  (Cfg.AxiDataWidth),
+        .NarrowDataWidth  (ClusterDataWidth),    // SCHEREMO: Convolve needs this...
         .WideDataWidth    (WideDataWidth),
         .NarrowIdWidthIn  (NarrowSlaveIdWidth),
         .WideIdWidthIn    (WideSlaveIdWidth),
@@ -440,13 +519,13 @@ module chimera_top_wrapper
         .RegisterCoreReq       (1),
         .RegisterCoreRsp       (1),
 
-        .narrow_in_req_t (axi_slv_req_t),
-        .narrow_in_resp_t(axi_slv_rsp_t),
+        .narrow_in_req_t (axi_cluster_in_narrow_req_t),
+        .narrow_in_resp_t(axi_cluster_in_narrow_resp_t),
         .wide_in_req_t   (axi_wide_slv_req_t),
         .wide_in_resp_t  (axi_wide_slv_rsp_t),
 
-        .narrow_out_req_t (axi_cluster_out_narrow_req_t),
-        .narrow_out_resp_t(axi_cluster_out_narrow_resp_t),
+        .narrow_out_req_t (axi_cluster_soc_out_narrow_req_t),
+        .narrow_out_resp_t(axi_cluster_soc_out_narrow_resp_t),
         .wide_out_req_t   (axi_cluster_out_wide_req_t),
         .wide_out_resp_t  (axi_cluster_out_wide_resp_t),
 

--- a/hw/narrow_adapter.sv
+++ b/hw/narrow_adapter.sv
@@ -1,0 +1,141 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Moritz Scherer <scheremo@iis.ee.ethz.ch>
+
+module narrow_adapter #(
+  parameter type narrow_in_req_t       = logic,
+  parameter type narrow_in_resp_t      = logic,
+  parameter type narrow_out_req_t      = logic,
+  parameter type narrow_out_resp_t     = logic,
+  parameter type clu_narrow_in_req_t   = logic,
+  parameter type clu_narrow_in_resp_t  = logic,
+  parameter type clu_narrow_out_req_t  = logic,
+  parameter type clu_narrow_out_resp_t = logic,
+  parameter int  MstPorts              = 2,
+  parameter int  SlvPorts              = 1
+) (
+  input logic soc_clk_i,
+  input logic rst_ni,
+
+  // From SoC
+  input  narrow_in_req_t   [SlvPorts-1:0] narrow_in_req_i,
+  output narrow_in_resp_t  [SlvPorts-1:0] narrow_in_resp_o,
+  output narrow_out_req_t  [MstPorts-1:0] narrow_out_req_o,
+  input  narrow_out_resp_t [MstPorts-1:0] narrow_out_resp_i,
+
+  // To Clu
+  output clu_narrow_in_req_t   [SlvPorts-1:0] clu_narrow_in_req_o,
+  input  clu_narrow_in_resp_t  [SlvPorts-1:0] clu_narrow_in_resp_i,
+  input  clu_narrow_out_req_t  [MstPorts-1:0] clu_narrow_out_req_i,
+  output clu_narrow_out_resp_t [MstPorts-1:0] clu_narrow_out_resp_o
+
+);
+
+  `include "axi/typedef.svh"
+
+  localparam int SoCNarrowDataWidth = $bits(narrow_out_req_o[0].w.data);
+  localparam int CluNarrowDataWidth = $bits(clu_narrow_in_req_o[0].w.data);
+  localparam int AddrWidth = $bits(narrow_out_req_o[0].aw.addr);
+  localparam int UserWidth = $bits(narrow_out_req_o[0].aw.user);
+
+  localparam int SocNarrowMasterIdWidth = $bits(narrow_out_req_o[0].aw.id);
+  localparam int SocNarrowSlaveIdWidth = $bits(narrow_in_req_i[0].aw.id);
+
+  typedef logic [UserWidth-1:0] axi_user_width_t;
+  typedef logic [AddrWidth-1:0] axi_addr_width_t;
+
+  typedef logic [SoCNarrowDataWidth-1:0] axi_soc_narrow_data_width_t;
+  typedef logic [SoCNarrowDataWidth/8-1:0] axi_soc_narrow_strb_width_t;
+
+  typedef logic [CluNarrowDataWidth-1:0] axi_clu_narrow_data_width_t;
+  typedef logic [CluNarrowDataWidth/8-1:0] axi_clu_narrow_strb_width_t;
+
+  typedef logic [SocNarrowMasterIdWidth-1:0] axi_narrow_mst_id_width_t;
+  typedef logic [SocNarrowSlaveIdWidth-1:0] axi_narrow_slv_id_width_t;
+
+  `AXI_TYPEDEF_ALL(axi_narrow_out_soc, axi_addr_width_t, axi_narrow_mst_id_width_t,
+                   axi_soc_narrow_data_width_t, axi_soc_narrow_strb_width_t, axi_user_width_t)
+
+  `AXI_TYPEDEF_ALL(axi_narrow_out_clu, axi_addr_width_t, axi_narrow_mst_id_width_t,
+                   axi_clu_narrow_data_width_t, axi_clu_narrow_strb_width_t, axi_user_width_t)
+
+  `AXI_TYPEDEF_ALL(axi_narrow_in_soc, axi_addr_width_t, axi_narrow_slv_id_width_t,
+                   axi_soc_narrow_data_width_t, axi_soc_narrow_strb_width_t, axi_user_width_t)
+
+  `AXI_TYPEDEF_ALL(axi_narrow_in_clu, axi_addr_width_t, axi_narrow_slv_id_width_t,
+                   axi_clu_narrow_data_width_t, axi_clu_narrow_strb_width_t, axi_user_width_t)
+
+
+  genvar i;
+  generate
+    for (i = 0; i < MstPorts; i++) begin : gen_clu_to_soc_conv
+      axi_dw_converter #(
+        .AxiMaxReads(2),
+
+        .AxiSlvPortDataWidth(CluNarrowDataWidth),
+        .AxiMstPortDataWidth(SoCNarrowDataWidth),
+        .AxiAddrWidth       (AddrWidth),
+        .AxiIdWidth         (SocNarrowMasterIdWidth),
+
+        .aw_chan_t(axi_narrow_out_soc_aw_chan_t),
+        .b_chan_t (axi_narrow_out_soc_b_chan_t),
+        .ar_chan_t(axi_narrow_out_soc_ar_chan_t),
+
+        .slv_r_chan_t(axi_narrow_out_clu_r_chan_t),
+        .slv_w_chan_t(axi_narrow_out_clu_aw_chan_t),
+        .mst_r_chan_t(axi_narrow_out_soc_r_chan_t),
+        .mst_w_chan_t(axi_narrow_out_soc_w_chan_t),
+
+        .axi_mst_req_t (axi_narrow_out_soc_req_t),
+        .axi_mst_resp_t(axi_narrow_out_soc_resp_t),
+        .axi_slv_req_t (clu_narrow_out_req_t),
+        .axi_slv_resp_t(clu_narrow_out_resp_t)
+      ) i_clu_to_soc_dw_converter (
+        .clk_i     (soc_clk_i),
+        .rst_ni,
+        .slv_req_i (clu_narrow_out_req_i[i]),
+        .slv_resp_o(clu_narrow_out_resp_o[i]),
+        .mst_req_o (narrow_out_req_o[i]),
+        .mst_resp_i(narrow_out_resp_i[i])
+      );
+    end
+
+  endgenerate
+  generate
+
+    for (i = 0; i < SlvPorts; i++) begin : gen_soc_to_clu_conv
+      axi_dw_converter #(
+        .AxiMaxReads(2),
+
+        .AxiSlvPortDataWidth(SoCNarrowDataWidth),
+        .AxiMstPortDataWidth(CluNarrowDataWidth),
+        .AxiAddrWidth       (AddrWidth),
+        .AxiIdWidth         (SocNarrowSlaveIdWidth),
+
+        .aw_chan_t(axi_narrow_in_clu_aw_chan_t),
+        .b_chan_t (axi_narrow_in_clu_b_chan_t),
+        .ar_chan_t(axi_narrow_in_clu_ar_chan_t),
+
+        .slv_r_chan_t(axi_narrow_in_soc_r_chan_t),
+        .slv_w_chan_t(axi_narrow_in_soc_w_chan_t),
+        .mst_r_chan_t(axi_narrow_in_clu_r_chan_t),
+        .mst_w_chan_t(axi_narrow_in_clu_w_chan_t),
+
+        .axi_mst_req_t (axi_narrow_in_clu_req_t),
+        .axi_mst_resp_t(axi_narrow_in_clu_resp_t),
+        .axi_slv_req_t (axi_narrow_in_soc_req_t),
+        .axi_slv_resp_t(axi_narrow_in_soc_resp_t)
+      ) i_soc_to_clu_dw_converter (
+        .clk_i     (soc_clk_i),
+        .rst_ni,
+        .slv_req_i (narrow_in_req_i[i]),
+        .slv_resp_o(narrow_in_resp_o[i]),
+        .mst_req_o (clu_narrow_in_req_o[i]),
+        .mst_resp_i(clu_narrow_in_resp_i[i])
+      );
+    end  // for (i = 0; i < SlvPorts; i++)
+  endgenerate
+
+endmodule

--- a/hw/narrow_adapter.sv
+++ b/hw/narrow_adapter.sv
@@ -68,74 +68,68 @@ module narrow_adapter #(
                    axi_clu_narrow_data_width_t, axi_clu_narrow_strb_width_t, axi_user_width_t)
 
 
-  genvar i;
-  generate
-    for (i = 0; i < MstPorts; i++) begin : gen_clu_to_soc_conv
-      axi_dw_converter #(
-        .AxiMaxReads(2),
+  for (genvar i = 0; i < MstPorts; i++) begin : gen_clu_to_soc_conv
+    axi_dw_converter #(
+      .AxiMaxReads(2),
 
-        .AxiSlvPortDataWidth(CluNarrowDataWidth),
-        .AxiMstPortDataWidth(SoCNarrowDataWidth),
-        .AxiAddrWidth       (AddrWidth),
-        .AxiIdWidth         (SocNarrowMasterIdWidth),
+      .AxiSlvPortDataWidth(CluNarrowDataWidth),
+      .AxiMstPortDataWidth(SoCNarrowDataWidth),
+      .AxiAddrWidth       (AddrWidth),
+      .AxiIdWidth         (SocNarrowMasterIdWidth),
 
-        .aw_chan_t(axi_narrow_out_soc_aw_chan_t),
-        .b_chan_t (axi_narrow_out_soc_b_chan_t),
-        .ar_chan_t(axi_narrow_out_soc_ar_chan_t),
+      .aw_chan_t(axi_narrow_out_soc_aw_chan_t),
+      .b_chan_t (axi_narrow_out_soc_b_chan_t),
+      .ar_chan_t(axi_narrow_out_soc_ar_chan_t),
 
-        .slv_r_chan_t(axi_narrow_out_clu_r_chan_t),
-        .slv_w_chan_t(axi_narrow_out_clu_aw_chan_t),
-        .mst_r_chan_t(axi_narrow_out_soc_r_chan_t),
-        .mst_w_chan_t(axi_narrow_out_soc_w_chan_t),
+      .slv_r_chan_t(axi_narrow_out_clu_r_chan_t),
+      .slv_w_chan_t(axi_narrow_out_clu_aw_chan_t),
+      .mst_r_chan_t(axi_narrow_out_soc_r_chan_t),
+      .mst_w_chan_t(axi_narrow_out_soc_w_chan_t),
 
-        .axi_mst_req_t (axi_narrow_out_soc_req_t),
-        .axi_mst_resp_t(axi_narrow_out_soc_resp_t),
-        .axi_slv_req_t (clu_narrow_out_req_t),
-        .axi_slv_resp_t(clu_narrow_out_resp_t)
-      ) i_clu_to_soc_dw_converter (
-        .clk_i     (soc_clk_i),
-        .rst_ni,
-        .slv_req_i (clu_narrow_out_req_i[i]),
-        .slv_resp_o(clu_narrow_out_resp_o[i]),
-        .mst_req_o (narrow_out_req_o[i]),
-        .mst_resp_i(narrow_out_resp_i[i])
-      );
-    end
+      .axi_mst_req_t (axi_narrow_out_soc_req_t),
+      .axi_mst_resp_t(axi_narrow_out_soc_resp_t),
+      .axi_slv_req_t (clu_narrow_out_req_t),
+      .axi_slv_resp_t(clu_narrow_out_resp_t)
+    ) i_clu_to_soc_dw_converter (
+      .clk_i     (soc_clk_i),
+      .rst_ni,
+      .slv_req_i (clu_narrow_out_req_i[i]),
+      .slv_resp_o(clu_narrow_out_resp_o[i]),
+      .mst_req_o (narrow_out_req_o[i]),
+      .mst_resp_i(narrow_out_resp_i[i])
+    );
+  end
 
-  endgenerate
-  generate
+  for (genvar i = 0; i < SlvPorts; i++) begin : gen_soc_to_clu_conv
+    axi_dw_converter #(
+      .AxiMaxReads(2),
 
-    for (i = 0; i < SlvPorts; i++) begin : gen_soc_to_clu_conv
-      axi_dw_converter #(
-        .AxiMaxReads(2),
+      .AxiSlvPortDataWidth(SoCNarrowDataWidth),
+      .AxiMstPortDataWidth(CluNarrowDataWidth),
+      .AxiAddrWidth       (AddrWidth),
+      .AxiIdWidth         (SocNarrowSlaveIdWidth),
 
-        .AxiSlvPortDataWidth(SoCNarrowDataWidth),
-        .AxiMstPortDataWidth(CluNarrowDataWidth),
-        .AxiAddrWidth       (AddrWidth),
-        .AxiIdWidth         (SocNarrowSlaveIdWidth),
+      .aw_chan_t(axi_narrow_in_clu_aw_chan_t),
+      .b_chan_t (axi_narrow_in_clu_b_chan_t),
+      .ar_chan_t(axi_narrow_in_clu_ar_chan_t),
 
-        .aw_chan_t(axi_narrow_in_clu_aw_chan_t),
-        .b_chan_t (axi_narrow_in_clu_b_chan_t),
-        .ar_chan_t(axi_narrow_in_clu_ar_chan_t),
+      .slv_r_chan_t(axi_narrow_in_soc_r_chan_t),
+      .slv_w_chan_t(axi_narrow_in_soc_w_chan_t),
+      .mst_r_chan_t(axi_narrow_in_clu_r_chan_t),
+      .mst_w_chan_t(axi_narrow_in_clu_w_chan_t),
 
-        .slv_r_chan_t(axi_narrow_in_soc_r_chan_t),
-        .slv_w_chan_t(axi_narrow_in_soc_w_chan_t),
-        .mst_r_chan_t(axi_narrow_in_clu_r_chan_t),
-        .mst_w_chan_t(axi_narrow_in_clu_w_chan_t),
-
-        .axi_mst_req_t (axi_narrow_in_clu_req_t),
-        .axi_mst_resp_t(axi_narrow_in_clu_resp_t),
-        .axi_slv_req_t (axi_narrow_in_soc_req_t),
-        .axi_slv_resp_t(axi_narrow_in_soc_resp_t)
-      ) i_soc_to_clu_dw_converter (
-        .clk_i     (soc_clk_i),
-        .rst_ni,
-        .slv_req_i (narrow_in_req_i[i]),
-        .slv_resp_o(narrow_in_resp_o[i]),
-        .mst_req_o (clu_narrow_in_req_o[i]),
-        .mst_resp_i(clu_narrow_in_resp_i[i])
-      );
-    end  // for (i = 0; i < SlvPorts; i++)
-  endgenerate
+      .axi_mst_req_t (axi_narrow_in_clu_req_t),
+      .axi_mst_resp_t(axi_narrow_in_clu_resp_t),
+      .axi_slv_req_t (axi_narrow_in_soc_req_t),
+      .axi_slv_resp_t(axi_narrow_in_soc_resp_t)
+    ) i_soc_to_clu_dw_converter (
+      .clk_i     (soc_clk_i),
+      .rst_ni,
+      .slv_req_i (narrow_in_req_i[i]),
+      .slv_resp_o(narrow_in_resp_o[i]),
+      .mst_req_o (clu_narrow_in_req_o[i]),
+      .mst_resp_i(clu_narrow_in_resp_i[i])
+    );
+  end  // for (i = 0; i < SlvPorts; i++)
 
 endmodule

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pyyaml
 mako
 jsonref
 jsonschema
+flatdict

--- a/target/sim/src/fixture_chimera_soc.sv
+++ b/target/sim/src/fixture_chimera_soc.sv
@@ -27,90 +27,76 @@ module fixture_chimera_soc #(
   //  DUT  //
   ///////////
 
-  logic                                       soc_clk;
-  logic                                       clu_clk;
-  logic                                       rst_n;
-  logic                                       test_mode;
-  logic [             1:0]                    boot_mode;
-  logic                                       rtc;
+  logic                 soc_clk;
+  logic                 clu_clk;
+  logic                 rst_n;
+  logic                 test_mode;
+  logic [          1:0] boot_mode;
+  logic                 rtc;
 
-  logic                                       jtag_tck;
-  logic                                       jtag_trst_n;
-  logic                                       jtag_tms;
-  logic                                       jtag_tdi;
-  logic                                       jtag_tdo;
+  logic                 jtag_tck;
+  logic                 jtag_trst_n;
+  logic                 jtag_tms;
+  logic                 jtag_tdi;
+  logic                 jtag_tdo;
 
-  logic                                       uart_tx;
-  logic                                       uart_rx;
+  logic                 uart_tx;
+  logic                 uart_rx;
 
-  logic                                       i2c_sda_o;
-  logic                                       i2c_sda_i;
-  logic                                       i2c_sda_en;
-  logic                                       i2c_scl_o;
-  logic                                       i2c_scl_i;
-  logic                                       i2c_scl_en;
+  logic                 i2c_sda_o;
+  logic                 i2c_sda_i;
+  logic                 i2c_sda_en;
+  logic                 i2c_scl_o;
+  logic                 i2c_scl_i;
+  logic                 i2c_scl_en;
 
-  logic                                       spih_sck_o;
-  logic                                       spih_sck_en;
-  logic [   SpihNumCs-1:0]                    spih_csb_o;
-  logic [   SpihNumCs-1:0]                    spih_csb_en;
-  logic [             3:0]                    spih_sd_o;
-  logic [             3:0]                    spih_sd_i;
-  logic [             3:0]                    spih_sd_en;
-
-  logic [SlinkNumChan-1:0]                    slink_rcv_clk_i;
-  logic [SlinkNumChan-1:0]                    slink_rcv_clk_o;
-  logic [SlinkNumChan-1:0][SlinkNumLanes-1:0] slink_i;
-  logic [SlinkNumChan-1:0][SlinkNumLanes-1:0] slink_o;
+  logic                 spih_sck_o;
+  logic                 spih_sck_en;
+  logic [SpihNumCs-1:0] spih_csb_o;
+  logic [SpihNumCs-1:0] spih_csb_en;
+  logic [          3:0] spih_sd_o;
+  logic [          3:0] spih_sd_i;
+  logic [          3:0] spih_sd_en;
 
   chimera_top_wrapper #(
     .SelectedCfg(SelectedCfg)
   ) dut (
-    .soc_clk_i      (soc_clk),
-    .clu_clk_i      (clu_clk),
-    .rst_ni         (rst_n),
-    .test_mode_i    (test_mode),
-    .boot_mode_i    (boot_mode),
-    .rtc_i          (rtc),
-    .jtag_tck_i     (jtag_tck),
-    .jtag_trst_ni   (jtag_trst_n),
-    .jtag_tms_i     (jtag_tms),
-    .jtag_tdi_i     (jtag_tdi),
-    .jtag_tdo_o     (jtag_tdo),
-    .jtag_tdo_oe_o  (),
-    .uart_tx_o      (uart_tx),
-    .uart_rx_i      (uart_rx),
-    .uart_rts_no    (),
-    .uart_dtr_no    (),
-    .uart_cts_ni    (1'b0),
-    .uart_dsr_ni    (1'b0),
-    .uart_dcd_ni    (1'b0),
-    .uart_rin_ni    (1'b0),
-    .i2c_sda_o      (i2c_sda_o),
-    .i2c_sda_i      (i2c_sda_i),
-    .i2c_sda_en_o   (i2c_sda_en),
-    .i2c_scl_o      (i2c_scl_o),
-    .i2c_scl_i      (i2c_scl_i),
-    .i2c_scl_en_o   (i2c_scl_en),
-    .spih_sck_o     (spih_sck_o),
-    .spih_sck_en_o  (spih_sck_en),
-    .spih_csb_o     (spih_csb_o),
-    .spih_csb_en_o  (spih_csb_en),
-    .spih_sd_o      (spih_sd_o),
-    .spih_sd_en_o   (spih_sd_en),
-    .spih_sd_i      (spih_sd_i),
-    .gpio_i         ('0),
-    .gpio_o         (),
-    .gpio_en_o      (),
-    .slink_rcv_clk_i(slink_rcv_clk_i),
-    .slink_rcv_clk_o(slink_rcv_clk_o),
-    .slink_i        (slink_i),
-    .slink_o        (slink_o),
-    .vga_hsync_o    (),
-    .vga_vsync_o    (),
-    .vga_red_o      (),
-    .vga_green_o    (),
-    .vga_blue_o     ()
+    .soc_clk_i    (soc_clk),
+    .clu_clk_i    (clu_clk),
+    .rst_ni       (rst_n),
+    .test_mode_i  (test_mode),
+    .boot_mode_i  (boot_mode),
+    .rtc_i        (rtc),
+    .jtag_tck_i   (jtag_tck),
+    .jtag_trst_ni (jtag_trst_n),
+    .jtag_tms_i   (jtag_tms),
+    .jtag_tdi_i   (jtag_tdi),
+    .jtag_tdo_o   (jtag_tdo),
+    .jtag_tdo_oe_o(),
+    .uart_tx_o    (uart_tx),
+    .uart_rx_i    (uart_rx),
+    .uart_rts_no  (),
+    .uart_dtr_no  (),
+    .uart_cts_ni  (1'b0),
+    .uart_dsr_ni  (1'b0),
+    .uart_dcd_ni  (1'b0),
+    .uart_rin_ni  (1'b0),
+    .i2c_sda_o    (i2c_sda_o),
+    .i2c_sda_i    (i2c_sda_i),
+    .i2c_sda_en_o (i2c_sda_en),
+    .i2c_scl_o    (i2c_scl_o),
+    .i2c_scl_i    (i2c_scl_i),
+    .i2c_scl_en_o (i2c_scl_en),
+    .spih_sck_o   (spih_sck_o),
+    .spih_sck_en_o(spih_sck_en),
+    .spih_csb_o   (spih_csb_o),
+    .spih_csb_en_o(spih_csb_en),
+    .spih_sd_o    (spih_sd_o),
+    .spih_sd_en_o (spih_sd_en),
+    .spih_sd_i    (spih_sd_i),
+    .gpio_i       ('0),
+    .gpio_o       (),
+    .gpio_en_o    ()
   );
 
   ////////////////////////
@@ -129,11 +115,6 @@ module fixture_chimera_soc #(
   ///////////
   //  VIP  //
   ///////////
-
-  axi_mst_req_t axi_slink_mst_req;
-  axi_mst_rsp_t axi_slink_mst_rsp;
-
-  assign axi_slink_mst_req = '0;
 
   vip_chimera_soc #(
     .DutCfg           (DutCfg),

--- a/target/sim/src/tb_chimera_soc.sv
+++ b/target/sim/src/tb_chimera_soc.sv
@@ -42,10 +42,6 @@ module tb_chimera_soc #(
           fix.vip.jtag_elf_run(preload_elf);
           fix.vip.jtag_wait_for_eoc(exit_code);
         end
-        1: begin  // Serial Link
-          fix.vip.slink_elf_run(preload_elf);
-          fix.vip.slink_wait_for_eoc(exit_code);
-        end
         2: begin  // UART
           fix.vip.uart_debug_elf_run_and_wait(preload_elf, exit_code);
         end

--- a/target/sim/src/vip_chimera_soc.sv
+++ b/target/sim/src/vip_chimera_soc.sv
@@ -42,35 +42,28 @@ module vip_chimera_soc
   parameter int unsigned AxiStrbWidth      = DutCfg.AxiDataWidth / 8,
   parameter int unsigned AxiStrbBits       = $clog2(DutCfg.AxiDataWidth / 8)
 ) (
-  output logic                                                   soc_clk,
-  output logic                                                   clu_clk,
-  output logic                                                   rst_n,
-  output logic                                                   test_mode,
-  output logic             [             1:0]                    boot_mode,
-  output logic                                                   rtc,
-  input  axi_ext_mst_req_t                                       axi_slink_mst_req,
-  output axi_ext_mst_rsp_t                                       axi_slink_mst_rsp,
+  output logic                 soc_clk,
+  output logic                 clu_clk,
+  output logic                 rst_n,
+  output logic                 test_mode,
+  output logic [          1:0] boot_mode,
+  output logic                 rtc,
   // JTAG interface
-  output logic                                                   jtag_tck,
-  output logic                                                   jtag_trst_n,
-  output logic                                                   jtag_tms,
-  output logic                                                   jtag_tdi,
-  input  logic                                                   jtag_tdo,
+  output logic                 jtag_tck,
+  output logic                 jtag_trst_n,
+  output logic                 jtag_tms,
+  output logic                 jtag_tdi,
+  input  logic                 jtag_tdo,
   // UART interface
-  input  logic                                                   uart_tx,
-  output logic                                                   uart_rx,
+  input  logic                 uart_tx,
+  output logic                 uart_rx,
   // I2C interface
-  inout  wire                                                    i2c_sda,
-  inout  wire                                                    i2c_scl,
+  inout  wire                  i2c_sda,
+  inout  wire                  i2c_scl,
   // SPI host interface
-  inout  wire                                                    spih_sck,
-  inout  wire              [   SpihNumCs-1:0]                    spih_csb,
-  inout  wire              [             3:0]                    spih_sd,
-  // Serial link interface
-  output logic             [SlinkNumChan-1:0]                    slink_rcv_clk_i,
-  input  logic             [SlinkNumChan-1:0]                    slink_rcv_clk_o,
-  output logic             [SlinkNumChan-1:0][SlinkNumLanes-1:0] slink_i,
-  input  logic             [SlinkNumChan-1:0][SlinkNumLanes-1:0] slink_o
+  inout  wire                  spih_sck,
+  inout  wire  [SpihNumCs-1:0] spih_csb,
+  inout  wire  [          3:0] spih_sd
 );
 
   `include "cheshire/typedef.svh"
@@ -150,7 +143,7 @@ module vip_chimera_soc
   localparam dm::sbcs_t JtagInitSbcs = '{
       sbautoincrement: 1'b1,
       sbreadondata: 1'b1,
-      sbaccess: 3,
+      sbaccess: $clog2(riscv::XLEN / 8),
       default: '0
   };
 
@@ -277,7 +270,7 @@ module vip_chimera_soc
       // Write address as 64-bit double
       jtag_write(dm::SBAddress1, sec_addr[63:32]);
       jtag_write(dm::SBAddress0, sec_addr[31:0]);
-      for (longint i = 0; i <= sec_len; i += 8) begin
+      for (longint i = 0; i <= sec_len; i += riscv::XLEN / 8) begin
         bit checkpoint = (i != 0 && i % 512 == 0);
         if (checkpoint)
           $display(
@@ -286,7 +279,7 @@ module vip_chimera_soc
               sec_len,
               i * 100 / (sec_len > 1 ? sec_len - 1 : 1)
           );
-        jtag_write(dm::SBData1, {bf[i+7], bf[i+6], bf[i+5], bf[i+4]});
+        jtag_write(dm::SBData1, {bf[i+7], bf[i+6], bf[i+5], bf[i+4]}, 0, 1);
         jtag_write(dm::SBData0, {bf[i+3], bf[i+2], bf[i+1], bf[i]}, 1, 1);
       end
     end
@@ -312,7 +305,11 @@ module vip_chimera_soc
     // Repoint execution
     jtag_write(dm::Data1, entry[63:32]);
     jtag_write(dm::Data0, entry[31:0]);
-    jtag_write(dm::Command, 32'h0023_07b1, 0, 1);
+    if (riscv::XLEN == 64) begin
+      jtag_write(dm::Command, 32'h0033_07b1, 0, 1);
+    end else begin
+      jtag_write(dm::Command, 32'h0023_07b1, 0, 1);
+    end
     // Resume hart 0
     jtag_write(dm::DMControl, dm::dmcontrol_t'{resumereq: 1, dmactive: 1, default: '0});
     $display("[JTAG] Resumed hart 0 from 0x%h", entry);
@@ -556,322 +553,6 @@ module vip_chimera_soc
     // We load an image into chip 0 only if it exists
     if (image != "") $readmemh(image, i_spi_norflash.Mem);
   endtask
-
-  ///////////////////
-  //  Serial Link  //
-  ///////////////////
-
-  axi_mst_req_t slink_axi_mst_req, slink_axi_slv_req;
-  axi_mst_rsp_t slink_axi_mst_rsp, slink_axi_slv_rsp;
-
-  AXI_BUS_DV #(
-    .AXI_ADDR_WIDTH(DutCfg.AddrWidth),
-    .AXI_DATA_WIDTH(DutCfg.AxiDataWidth),
-    .AXI_ID_WIDTH  (DutCfg.AxiMstIdWidth),
-    .AXI_USER_WIDTH(DutCfg.AxiUserWidth)
-  ) slink_mst_vip_dv (
-    .clk_i(soc_clk)
-  );
-
-  AXI_BUS #(
-    .AXI_ADDR_WIDTH(DutCfg.AddrWidth),
-    .AXI_DATA_WIDTH(DutCfg.AxiDataWidth),
-    .AXI_ID_WIDTH  (DutCfg.AxiMstIdWidth),
-    .AXI_USER_WIDTH(DutCfg.AxiUserWidth)
-  )
-      slink_mst_ext (), slink_mst_vip (), slink_mst ();
-
-  AXI_BUS #(
-    .AXI_ADDR_WIDTH(DutCfg.AddrWidth),
-    .AXI_DATA_WIDTH(DutCfg.AxiDataWidth),
-    .AXI_ID_WIDTH  (DutCfg.AxiMstIdWidth + 1),
-    .AXI_USER_WIDTH(DutCfg.AxiUserWidth)
-  ) slink_mst_mux ();
-
-  AXI_BUS_DV #(
-    .AXI_ADDR_WIDTH(DutCfg.AddrWidth),
-    .AXI_DATA_WIDTH(DutCfg.AxiDataWidth),
-    .AXI_ID_WIDTH  (DutCfg.AxiMstIdWidth),
-    .AXI_USER_WIDTH(DutCfg.AxiUserWidth)
-  ) slink_slv (
-    .clk_i(soc_clk)
-  );
-
-  // Multiplex internal and external AXI requests
-  axi_mux_intf #(
-    .SLV_AXI_ID_WIDTH(DutCfg.AxiMstIdWidth),
-    .MST_AXI_ID_WIDTH(DutCfg.AxiMstIdWidth + 1),
-    .AXI_ADDR_WIDTH  (DutCfg.AddrWidth),
-    .AXI_DATA_WIDTH  (DutCfg.AxiDataWidth),
-    .AXI_USER_WIDTH  (DutCfg.AxiUserWidth),
-    .NO_SLV_PORTS    (2)
-  ) i_axi_mux_slink (
-    .clk_i (soc_clk),
-    .rst_ni(rst_n),
-    .test_i(test_mode),
-    .slv   ('{slink_mst_vip, slink_mst_ext}),
-    .mst   (slink_mst_mux)
-  );
-
-  // Serialize away added AXI index bits
-  axi_id_serialize_intf #(
-    .AXI_SLV_PORT_ID_WIDTH       (DutCfg.AxiMstIdWidth + 1),
-    .AXI_SLV_PORT_MAX_TXNS       (SlinkMaxTxns),
-    .AXI_MST_PORT_ID_WIDTH       (DutCfg.AxiMstIdWidth),
-    .AXI_MST_PORT_MAX_UNIQ_IDS   (2 ** DutCfg.AxiMstIdWidth),
-    .AXI_MST_PORT_MAX_TXNS_PER_ID(SlinkMaxTxnsPerId),
-    .AXI_ADDR_WIDTH              (DutCfg.AddrWidth),
-    .AXI_DATA_WIDTH              (DutCfg.AxiDataWidth),
-    .AXI_USER_WIDTH              (DutCfg.AxiUserWidth)
-  ) i_axi_id_serialize_slink (
-    .clk_i (soc_clk),
-    .rst_ni(rst_n),
-    .slv   (slink_mst_mux),
-    .mst   (slink_mst)
-  );
-
-  `AXI_ASSIGN(slink_mst_vip, slink_mst_vip_dv)
-
-  `AXI_ASSIGN_FROM_REQ(slink_mst_ext, axi_slink_mst_req)
-  `AXI_ASSIGN_TO_RESP(axi_slink_mst_rsp, slink_mst_ext)
-
-  `AXI_ASSIGN_TO_REQ(slink_axi_mst_req, slink_mst)
-  `AXI_ASSIGN_FROM_RESP(slink_mst, slink_axi_mst_rsp)
-
-  `AXI_ASSIGN_FROM_REQ(slink_slv, slink_axi_slv_req)
-  `AXI_ASSIGN_TO_RESP(slink_axi_slv_rsp, slink_slv)
-
-  // Mirror instance of serial link, reflecting another chip
-  serial_link #(
-    .axi_req_t  (axi_mst_req_t),
-    .axi_rsp_t  (axi_mst_rsp_t),
-    .cfg_req_t  (reg_req_t),
-    .cfg_rsp_t  (reg_rsp_t),
-    .aw_chan_t  (axi_mst_aw_chan_t),
-    .ar_chan_t  (axi_mst_ar_chan_t),
-    .r_chan_t   (axi_mst_r_chan_t),
-    .w_chan_t   (axi_mst_w_chan_t),
-    .b_chan_t   (axi_mst_b_chan_t),
-    .hw2reg_t   (serial_link_single_channel_reg_pkg::serial_link_single_channel_hw2reg_t),
-    .reg2hw_t   (serial_link_single_channel_reg_pkg::serial_link_single_channel_reg2hw_t),
-    .NumChannels(SlinkNumChan),
-    .NumLanes   (SlinkNumLanes),
-    .MaxClkDiv  (SlinkMaxClkDiv)
-  ) i_serial_link (
-    .clk_i        (soc_clk),
-    .rst_ni       (rst_n),
-    .clk_sl_i     (clk),
-    .rst_sl_ni    (rst_n),
-    .clk_reg_i    (clk),
-    .rst_reg_ni   (rst_n),
-    .testmode_i   (test_mode),
-    .axi_in_req_i (slink_axi_mst_req),
-    .axi_in_rsp_o (slink_axi_mst_rsp),
-    .axi_out_req_o(slink_axi_slv_req),
-    .axi_out_rsp_i(slink_axi_slv_rsp),
-    .cfg_req_i    ('0),
-    .cfg_rsp_o    (),
-    .ddr_rcv_clk_i(slink_rcv_clk_o),
-    .ddr_rcv_clk_o(slink_rcv_clk_i),
-    .ddr_i        (slink_o),
-    .ddr_o        (slink_i),
-    .isolated_i   ('0),
-    .isolate_o    (),
-    .clk_ena_o    (),
-    .reset_no     ()
-  );
-
-  // We terminate the slave interface with a random agent
-  axi_test::axi_rand_slave #(
-    .AW                  (DutCfg.AddrWidth),
-    .DW                  (DutCfg.AxiDataWidth),
-    .IW                  (DutCfg.AxiMstIdWidth),
-    .UW                  (DutCfg.AxiUserWidth),
-    .MAPPED              (1'b1),
-    .TA                  (ClkPeriodSys * TAppl),
-    .TT                  (ClkPeriodSys * TTest),
-    .RAND_RESP           (0),
-    .AX_MIN_WAIT_CYCLES  (0),
-    .AX_MAX_WAIT_CYCLES  (SlinkMaxWaitAx),
-    .R_MIN_WAIT_CYCLES   (0),
-    .R_MAX_WAIT_CYCLES   (SlinkMaxWaitR),
-    .RESP_MIN_WAIT_CYCLES(0),
-    .RESP_MAX_WAIT_CYCLES(SlinkMaxWaitResp)
-  ) i_slink_rand_slv = new(
-      slink_slv
-  );
-
-  initial begin
-    i_slink_rand_slv.run();
-  end
-
-  // We use an AXI driver to inject serial link transfers
-  typedef axi_test::axi_driver#(
-    .AW(DutCfg.AddrWidth),
-    .DW(DutCfg.AxiDataWidth),
-    .IW(DutCfg.AxiMstIdWidth),
-    .UW(DutCfg.AxiUserWidth),
-    .TA(ClkPeriodSys * TAppl),
-    .TT(ClkPeriodSys * TTest)
-  ) slink_axi_driver_t;
-
-  slink_axi_driver_t slink_axi_driver = new(slink_mst_vip_dv);
-
-  initial begin
-    @(negedge rst_n);
-    slink_axi_driver.reset_master();
-  end
-
-  task automatic slink_write_beats(input addr_t addr, input axi_pkg::size_t size,
-                                   ref axi_data_t beats[$]);
-    slink_axi_driver_t::ax_beat_t ax = new();
-    slink_axi_driver_t::w_beat_t  w = new();
-    slink_axi_driver_t::b_beat_t  b;
-    int                           i = 0;
-    int                           size_bytes = (1 << size);
-    if (beats.size() == 0) $fatal(1, "[SLINK] Zero-length write requested!");
-    @(posedge clk);
-    if (SlinkAxiDebug) $display("[SLINK] Write to address: %h, len: %0d", addr, beats.size() - 1);
-    ax.ax_addr  = addr;
-    ax.ax_id    = '0;
-    ax.ax_len   = beats.size() - 1;
-    ax.ax_size  = size;
-    ax.ax_burst = axi_pkg::BURST_INCR;
-    if (SlinkAxiDebug) $display("[SLINK] - Sending AW ");
-    slink_axi_driver.send_aw(ax);
-    do begin
-      w.w_strb = i == 0 ? (~('1 << size_bytes)) << addr[AxiStrbBits-1:0] : '1;
-      w.w_data = beats[i];
-      w.w_last = (i == ax.ax_len);
-      if (SlinkAxiDebug) $display("[SLINK] - Sending W (%0d)", i);
-      slink_axi_driver.send_w(w);
-      addr += size_bytes;
-      addr &= size_bytes - 1;
-      i++;
-    end while (i <= ax.ax_len);
-    if (SlinkAxiDebug) $display("[SLINK] - Receiving B");
-    slink_axi_driver.recv_b(b);
-    if (b.b_resp != axi_pkg::RESP_OKAY) $error("[SLINK] - Write error response: %d!", b.b_resp);
-    if (SlinkAxiDebug) $display("[SLINK] - Done");
-  endtask
-
-  task automatic slink_read_beats(input addr_t addr, input axi_pkg::size_t size,
-                                  input axi_pkg::len_t len, ref axi_data_t beats[$]);
-    slink_axi_driver_t::ax_beat_t ax = new();
-    slink_axi_driver_t::r_beat_t  r;
-    int                           i = 0;
-    @(posedge clk)
-      if (SlinkAxiDebug)
-        $display("[SLINK] Read from address: %h, len: %0d", addr, len);
-    ax.ax_addr  = addr;
-    ax.ax_id    = '0;
-    ax.ax_len   = len;
-    ax.ax_size  = size;
-    ax.ax_burst = axi_pkg::BURST_INCR;
-    if (SlinkAxiDebug) $display("[SLINK] - Sending AR");
-    slink_axi_driver.send_ar(ax);
-    do begin
-      if (SlinkAxiDebug) $display("[SLINK] - Receiving R (%0d)", i);
-      slink_axi_driver.recv_r(r);
-      beats.push_back(r.r_data);
-      addr += (1 << size);
-      addr &= (1 << size) - 1;
-      i++;
-      if (r.r_resp != axi_pkg::RESP_OKAY) $error("[SLINK] - Read error response: %d!", r.r_resp);
-    end while (!r.r_last);
-    if (SlinkAxiDebug) $display("[SLINK] - Done");
-  endtask
-
-  task automatic slink_write_32(input addr_t addr, input word_bt data);
-    axi_data_t beats[$];
-    beats.push_back(data << (8 * addr[AxiStrbBits-1:0]));
-    slink_write_beats(addr, 2, beats);
-  endtask
-
-  task automatic slink_poll_bit0(input doub_bt addr, output word_bt data,
-                                 input int unsigned idle_cycles);
-    do begin
-      axi_data_t beats[$];
-      #(ClkPeriodSys * idle_cycles);
-      slink_read_beats(addr, 2, 0, beats);
-      data = beats[0] >> addr[AxiStrbBits-1:0];
-    end while (~data[0]);
-  endtask
-
-  // Load a binary
-  task automatic slink_elf_preload(input string binary, output doub_bt entry);
-    longint sec_addr, sec_len, bus_offset, write_addr;
-    $display("[SLINK] Preloading ELF binary: %s", binary);
-    if (read_elf(binary)) $fatal(1, "[SLINK] Failed to load ELF!");
-    while (get_section(
-        sec_addr, sec_len
-    )) begin
-      byte bf[] = new[sec_len];
-      $display("[SLINK] Preloading section at 0x%h (%0d bytes)", sec_addr, sec_len);
-      if (read_section(sec_addr, bf, sec_len)) $fatal(1, "[SLINK] Failed to read ELF section!");
-      // Write section as fixed-size bursts
-      bus_offset = sec_addr[AxiStrbBits-1:0];
-      for (longint i = 0; i <= sec_len; i += SlinkBurstBytes) begin
-        axi_data_t beats[$];
-        if (i != 0)
-          $display(
-              "[SLINK] - %0d/%0d bytes (%0d%%)",
-              i,
-              sec_len,
-              i * 100 / (sec_len > 1 ? sec_len - 1 : 1)
-          );
-        // Assemble beats for current burst from section buffer
-        for (int b = 0; b < SlinkBurstBytes; b += AxiStrbWidth) begin
-          axi_data_t beat;
-          // We handle incomplete bursts
-          if (i + b - bus_offset >= sec_len) break;
-          for (int e = 0; e < AxiStrbWidth; ++e)
-          if (i + b + e < bus_offset) begin
-            beat[8*e+:8] = '0;
-          end else if (i + b + e - bus_offset >= sec_len) begin
-            beat[8*e+:8] = '0;
-          end else begin
-            beat[8*e+:8] = bf[i+b+e-bus_offset];
-          end
-
-          beats.push_back(beat);
-        end
-        write_addr = sec_addr + (i == 0 ? 0 : i - sec_addr % AxiStrbWidth);
-        // Write this burst
-        slink_write_beats(write_addr, AxiStrbBits, beats);
-      end
-    end
-    void'(get_entry(entry));
-    $display("[SLINK] Preload complete");
-  endtask
-
-  // Run a binary
-  task automatic slink_elf_run(input string binary);
-    doub_bt entry;
-    // Wait for bootrom to ungate Serial Link
-    if (DutCfg.LlcNotBypass) begin
-      word_bt regval;
-      $display("[SLINK] Wait for LLC configuration");
-      slink_poll_bit0(AmLlc + axi_llc_reg_pkg::AXI_LLC_CFG_SPM_LOW_OFFSET, regval, 20);
-    end
-    // Preload
-    slink_elf_preload(binary, entry);
-    // Write entry point
-    slink_write_32(AmRegs + cheshire_reg_pkg::CHESHIRE_SCRATCH_1_OFFSET, entry[63:32]);
-    slink_write_32(AmRegs + cheshire_reg_pkg::CHESHIRE_SCRATCH_0_OFFSET, entry[32:0]);
-    // Resume hart 0
-    slink_write_32(AmRegs + cheshire_reg_pkg::CHESHIRE_SCRATCH_2_OFFSET, 2);
-    $display("[SLINK] Wrote launch signal and entry point 0x%h", entry);
-  endtask
-
-  // Wait for termination signal and get return code
-  task automatic slink_wait_for_eoc(output word_bt exit_code);
-    slink_poll_bit0(AmRegs + cheshire_reg_pkg::CHESHIRE_SCRATCH_2_OFFSET, exit_code, 800);
-    exit_code >>= 1;
-    if (exit_code) $error("[SLINK] FAILED: return code %0d", exit_code);
-    else $display("[SLINK] SUCCESS");
-  endtask
-
 
 endmodule
 


### PR DESCRIPTION
Introduces support for 32 Bit host system (AXI Addrwidth & Datawidth) with Clusters using 32 Bit Addrwidth and 64 Bit Datawidth. 

## Added
* `narrow_adapter` to adapter between 32 Bit and 64 Bit Datawidth domains.

## Changed
* Default Cfg now uses 32 Bit `AxiDataWidth` and 32 Bit `AddressWidth` Host
* Default Cfg now uses 64 Bit `DataWidth`  and 32 Bit `AddressWidth` Snitch Clusters. Adjustable via `chimera_pkg`
* Bumped `iDMA` commit which fixes incompatibility with mixed 64- and 32-Bit Datawidth systems

## Removed
* Removed `slink`, `VGA`, `USB` ports from `chimera_top_wrapper`
* Removed `slink`-specific fixture functions