### PR TITLE
Revert Commit #69cc1bc

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -198,8 +198,8 @@ packages:
     - common_verification
     - tech_cells_generic
   obi:
-    revision: 5321106817e177d6c16ecc4daa922b96b1bc946b
-    version: 0.1.5
+    revision: c2141a653c755461ff44f61d12aeb5d99fc8e760
+    version: 0.1.3
     source:
       Git: https://github.com/pulp-platform/obi.git
     dependencies:
@@ -225,10 +225,10 @@ packages:
     - common_cells
     - common_verification
   riscv-dbg:
-    revision: 5b21f3504fc3913320b39b477ef2a4274e09581d
-    version: null
+    revision: 358f90110220adf7a083f8b65d157e836d706236
+    version: 0.8.1
     source:
-      Git: https://github.com/pulp-platform/riscv-dbg
+      Git: https://github.com/pulp-platform/riscv-dbg.git
     dependencies:
     - common_cells
     - tech_cells_generic

--- a/Bender.yml
+++ b/Bender.yml
@@ -11,7 +11,6 @@ dependencies:
   register_interface:       { git: "https://github.com/pulp-platform/register_interface.git", version: 0.4.3  }
   axi:                      { git: "https://github.com/pulp-platform/axi.git",                version: 0.39.2 }
   cheshire:                 { git: "https://github.com/pulp-platform/cheshire.git",           rev: 4dfba37385eae48c44080defdfaa3f580921a60c}
-  riscv-dbg:                { git: "https://github.com/pulp-platform/riscv-dbg",              rev: 5b21f3504fc3913320b39b477ef2a4274e09581d}
   snitch_cluster:           { git: "https://github.com/pulp-platform/snitch_cluster.git",     rev: c12ce9b2af1ac8edf3d4feb18939e1ad20c42225}
   common_cells:             { git: "https://github.com/pulp-platform/common_cells.git",       version: 1.31.1}
   idma:                     { git: "https://github.com/pulp-platform/iDMA.git",               rev: 9edf489f57389dce5e71252c79e337f527d3aded}


### PR DESCRIPTION
After discussion here: https://github.com/pulp-platform/riscv-dbg/pull/171

We can revert the latest commit; the "proper" fix is to relax JTAG frequency.