### PR TITLE
Improve makefile flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 transcript
 .bender
 .venv
+cheshire
+idma
 
 # EMACS
 
@@ -21,6 +23,10 @@ hw/regs/pcr.md
 __pycache__
 *.o
 *.a
+
+# UTILS
+
+utils/verible-verilog
 
 # SIM
 

--- a/Makefile
+++ b/Makefile
@@ -4,16 +4,17 @@
 #
 # Moritz Scherer <scheremo@iis.ee.ethz.ch>
 
-CHIM_ROOT      ?= $(shell pwd)
-BENDER   ?= bender -d $(CHIM_ROOT)
+CHIM_ROOT ?= $(shell pwd)
+BENDER    ?= bender -d $(CHIM_ROOT)
 
-CHS_ROOT      ?= $(shell $(BENDER) path cheshire)
-SNITCH_ROOT      ?= $(shell $(BENDER) path snitch_cluster)
-IDMA_ROOT      ?= $(shell $(BENDER) path idma)
+CHS_ROOT    ?= $(shell $(BENDER) path cheshire)
+SNITCH_ROOT ?= $(shell $(BENDER) path snitch_cluster)
+IDMA_ROOT   ?= $(shell $(BENDER) path idma)
+
 CHS_XLEN ?= 32
 
-CHIM_HW_DIR      ?= $(CHIM_ROOT)/hw
-CHIM_SW_DIR      ?= $(CHIM_ROOT)/sw
+CHIM_HW_DIR ?= $(CHIM_ROOT)/hw
+CHIM_SW_DIR ?= $(CHIM_ROOT)/sw
 
 -include $(CHS_ROOT)/cheshire.mk
 -include $(CHIM_ROOT)/chimera.mk

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,11 @@
 # Moritz Scherer <scheremo@iis.ee.ethz.ch>
 
 CHIM_ROOT ?= $(shell pwd)
-BENDER    ?= bender -d $(CHIM_ROOT)
-PADRICK   ?= padrick
+
+# Tooling
+BENDER                 ?= bender -d $(CHIM_ROOT)
+PADRICK                ?= padrick
+VERIBLE_VERILOG_FORMAT ?= $(CHIM_UTILS_DIR)/verible-verilog/verible-verilog-format
 
 CHS_ROOT    ?= $(shell $(BENDER) path cheshire)
 SNITCH_ROOT ?= $(shell $(BENDER) path snitch_cluster)

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@
 
 CHIM_ROOT ?= $(shell pwd)
 BENDER    ?= bender -d $(CHIM_ROOT)
+PADRICK   ?= padrick
 
 CHS_ROOT    ?= $(shell $(BENDER) path cheshire)
 SNITCH_ROOT ?= $(shell $(BENDER) path snitch_cluster)

--- a/chimera.mk
+++ b/chimera.mk
@@ -72,7 +72,9 @@ chim-nonfree-init:
 -include $(CHIM_NONFREE_DIR)/nonfree.mk
 
 -include $(CHIM_ROOT)/bender.mk
+
 # Include subdir Makefiles
 -include $(CHIM_ROOT)/sw/sw.mk
+-include $(CHIM_ROOT)/utils/utils.mk
 # Include target makefiles
 -include $(CHIM_ROOT)/target/sim/sim.mk

--- a/chimera.mk
+++ b/chimera.mk
@@ -71,8 +71,8 @@ chim-nonfree-init:
 
 -include $(CHIM_NONFREE_DIR)/nonfree.mk
 
-
 -include $(CHIM_ROOT)/bender.mk
-
--include $(CHIM_ROOT)/sim.mk
+# Include subdir Makefiles
 -include $(CHIM_ROOT)/sw/sw.mk
+# Include target makefiles
+-include $(CHIM_ROOT)/target/sim/sim.mk

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ mako
 jsonref
 jsonschema
 flatdict
+padrick @ git+https://github.com/pulp-platform/padrick@v0.3.6

--- a/sw/sw.mk
+++ b/sw/sw.mk
@@ -4,6 +4,9 @@
 #
 # Moritz Scherer <scheremo@iis.ee.ethz.ch>
 
+ifndef chim_sw_mk
+chim_sw_mk=1
+
 CHS_SW_INCLUDES += -I$(CHIM_SW_DIR)/include
 CHS_SW_FLAGS += -falign-functions=64 -march=rv32im
 CHS_SW_LDFLAGS += -L$(CHIM_SW_DIR)/lib
@@ -33,3 +36,5 @@ chim-sw-clean:
 	@find sw/tests | grep ".*\.dump" | xargs -I ! rm !
 	@find sw/tests | grep ".*\.memh" | xargs -I ! rm !
 	@find sw/lib | grep ".*\.a" | xargs -I ! rm !
+
+endif # chim_sw_mk

--- a/target/sim/sim.mk
+++ b/target/sim/sim.mk
@@ -4,16 +4,22 @@
 #
 # Moritz Scherer <scheremo@iis.ee.ethz.ch>
 
+ifndef chim_sim_mk
+chim_sim_mk=1
+
+CHIM_SIM_DIR ?= $(CHIM_ROOT)/target/sim
+
 .PHONY: sim sim-clean
 
 chim-sim-clean:
-	@rm -rf target/sim/vsim/work
-	@rm -rf target/sim/vsim/transcript
-	@rm -f $(CHIM_ROOT)/target/sim/vsim/compile.tcl
+	@rm -rf $(CHIM_SIM_DIR)/vsim/work
+	@rm -rf $(CHIM_SIM_DIR)/vsim/transcript
+	@rm -f $(CHIM_SIM_DIR)/vsim/compile.tcl
 
-chim-sim: $(CHIM_ROOT)/target/sim/vsim/compile.tcl
+chim-sim: $(CHIM_SIM_DIR)/vsim/compile.tcl
 
-$(CHIM_ROOT)/target/sim/vsim/compile.tcl: chs-hw-init snitch-hw-init
+$(CHIM_SIM_DIR)/vsim/compile.tcl: chs-hw-init snitch-hw-init
 	@bender script vsim $(COMMON_TARGS) $(SIM_TARGS) --vlog-arg="$(VLOG_ARGS)"> $@
 	echo 'vlog "$(realpath $(CHS_ROOT))/target/sim/src/elfloader.cpp" -ccflags "-std=c++11"' >> $@
 
+endif # chim_sim_mk

--- a/utils/utils.mk
+++ b/utils/utils.mk
@@ -1,0 +1,41 @@
+# Copyright 2024 ETH Zurich and University of Bologna.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Sergio Mazzola <smazzola@iis.ee.ethz.ch>
+
+ifndef chim_utils_mk
+chim_utils_mk=1
+
+CHIM_UTILS_DIR ?= $(CHIM_ROOT)/utils
+
+# Verilog formatting
+FORMAT_VERILOG_SRC = $(wildcard \
+	hw/*.sv \
+	target/sim/src/*.sv \
+	target/fpga/src/chimera/*.sv \
+)
+
+# Checks if verible-verilog-format is installed, otherwise it looks for a Makefile target in our flow to install it
+format-verilog: $(shell if ! `which $(VERIBLE_VERILOG_FORMAT)`; then echo $(VERIBLE_VERILOG_FORMAT); fi)
+	$(VERIBLE_VERILOG_FORMAT) --flagfile .verilog_format --inplace --verbose $(FORMAT_VERILOG_SRC)
+
+# Download verible-verilog-format
+$(CHIM_UTILS_DIR)/verible-verilog/verible-verilog-format:
+	mkdir -p $(CHIM_UTILS_DIR)/verible-verilog
+	cd $(CHIM_UTILS_DIR)/verible-verilog && curl https://api.github.com/repos/chipsalliance/verible/releases/tags/v0.0-3752-g8b64887e \
+	| grep "browser_download_url.*verible-v0.0-3752-g8b64887e-linux-static-x86_64.tar.gz" \
+	| cut -d : -f 2,3 \
+	| tr -d \" \
+	| wget -qi -
+	tar -xvzf $(CHIM_UTILS_DIR)/verible-verilog/verible-v0.0-3752-g8b64887e-linux-static-x86_64.tar.gz -C $(CHIM_UTILS_DIR)/verible-verilog
+	chmod a+x $(CHIM_UTILS_DIR)/verible-verilog/verible-v0.0-3752-g8b64887e/bin/*
+	mv $(CHIM_UTILS_DIR)/verible-verilog/verible-v0.0-3752-g8b64887e/bin/* $(CHIM_UTILS_DIR)/verible-verilog
+	rm -rf $(CHIM_UTILS_DIR)/verible-verilog/verible-v0.0-3752-g8b64887e*
+
+# Clean up
+.PHONY: utils-clean
+utils-clean:
+	@rm -rf $(CHIM_UTILS_DIR)/verible-verilog
+
+endif # chim_utils_mk


### PR DESCRIPTION
This PR is an attempt to improve the makefile flow of the project.
Makefrags of each project directory (`utils`, `sw`, `target/*`) are now located in that directory, and included from the main `chimera.mk` makefile (see https://github.com/pulp-platform/chimera/pull/28/files#diff-00aa5349c729bdf6161632c838730b4db54ca6a45d2276428467a47c553278f7R75-R79).

This gives maximum flexibility for the "interaction" of different makefrags, and also keeps things tidy as the root directory does not contain anymore many different unrelated makefrags.
Each directory's makefrag also has an include guard to prevent multiple inclusions.
Moreover, all targets can be called from the root directory.

Additionally, the padrick binary is now downloaded as part of `utils` through the makefile.
This is useful for when the asic and fpga will be integrated.

This flow is flexible enough that, as an example use case, the makefile target downloading padrick (in the utils directory) can be directly triggered from the makefile of the fpga target when it has to generate the padframe.

What do you think of this flow?


