### PR TITLE
ASIC Target

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -14,6 +14,7 @@ dependencies:
   snitch_cluster:           { git: "https://github.com/pulp-platform/snitch_cluster.git",     rev: c12ce9b2af1ac8edf3d4feb18939e1ad20c42225}
   common_cells:             { git: "https://github.com/pulp-platform/common_cells.git",       version: 1.31.1}
   idma:                     { git: "https://github.com/pulp-platform/iDMA.git",               rev: 9edf489f57389dce5e71252c79e337f527d3aded}
+  apb:                      { git: "https://github.com/pulp-platform/apb.git",                version: 0.2.4          }
 
 workspace:
   package_links:

--- a/hw/chimera_pkg.sv
+++ b/hw/chimera_pkg.sv
@@ -8,6 +8,8 @@ package chimera_pkg;
 
   import cheshire_pkg::*;
 
+  `include "apb/typedef.svh"
+
   // ACCEL CFG
   localparam int ExtClusters = 5;
 
@@ -35,8 +37,8 @@ package chimera_pkg;
   // SoC Config
   localparam int SnitchBootROM = 1;
 
-  // SCHEREMO: Shared Snitch bootrom, one clock gate per cluster
-  localparam int ExtRegNum = SnitchBootROM + 1;
+  // SCHEREMO: Shared Snitch bootrom, one clock gate per cluster, Fll cfg regs, Pad cfg regs
+  localparam int ExtRegNum = SnitchBootROM + 1 + 1 + 1;
   localparam int ClusterDataWidth = 64;
 
   localparam int SnitchBootROMIdx = 0;
@@ -46,6 +48,17 @@ package chimera_pkg;
   localparam int TopLevelIdx = 1;
   localparam doub_bt TopLevelRegionStart = 64'h3000_1000;
   localparam doub_bt TopLevelRegionEnd = 64'h3000_2000;
+
+  // PADs external configuration registers
+  localparam int PadIdx = 2;
+  localparam doub_bt PadRegionStart = 64'h3000_2000;
+  localparam doub_bt PadRegionEnd = 64'h3000_3000;
+
+  // FLL external configuration registers
+  localparam int FllIdx = 3;
+  localparam doub_bt FllRegionStart = 64'h3000_3000;
+  localparam doub_bt FllRegionEnd = 64'h3000_4000;
+
 
   localparam aw_bt ClusterNarrowAxiMstIdWidth = 1;
 
@@ -92,9 +105,11 @@ package chimera_pkg;
     // REG CFG
     cfg.RegExtNumSlv = ExtRegNum;
     cfg.RegExtNumRules = ExtRegNum;
-    cfg.RegExtRegionIdx = {8'h1, 8'h0};  // SnitchBootROM
-    cfg.RegExtRegionStart = {TopLevelRegionStart, SnitchBootROMRegionStart};
-    cfg.RegExtRegionEnd = {TopLevelRegionEnd, SnitchBootROMRegionEnd};
+    cfg.RegExtRegionIdx = {8'h3, 8'h2, 8'h1, 8'h0};  // SnitchBootROM
+    cfg.RegExtRegionStart = {
+      FllRegionStart, PadRegionStart, TopLevelRegionStart, SnitchBootROMRegionStart
+    };
+    cfg.RegExtRegionEnd = {FllRegionEnd, PadRegionEnd, TopLevelRegionEnd, SnitchBootROMRegionEnd};
 
     // ACCEL HART/IRQ CFG
     cfg.NumExtIrqHarts = ExtCores;
@@ -107,4 +122,14 @@ package chimera_pkg;
   localparam int NumCfgs = 1;
 
   localparam cheshire_cfg_t [NumCfgs-1:0] ChimeraCfg = {gen_chimera_cfg()};
+
+  // To move into cheshire TYPEDEF
+  localparam int unsigned RegDataWidth = 32;
+  localparam type addr_t = logic [DefaultCfg.AddrWidth-1:0];
+  // localparam type data_t = logic[DefaultCfg.AxiDataWidth];
+  localparam type data_t = logic [RegDataWidth-1:0];
+  localparam type strb_t = logic [RegDataWidth/8-1:0];
+
+  `APB_TYPEDEF_ALL(apb, addr_t, data_t, strb_t)
+
 endpackage

--- a/hw/chimera_top_wrapper.sv
+++ b/hw/chimera_top_wrapper.sv
@@ -11,48 +11,54 @@ module chimera_top_wrapper
 #(
   parameter int unsigned SelectedCfg = 0
 ) (
-  input  logic                 soc_clk_i,
-  input  logic                 clu_clk_i,
-  input  logic                 rst_ni,
-  input  logic                 test_mode_i,
-  input  logic [          1:0] boot_mode_i,
-  input  logic                 rtc_i,
+  input  logic                      soc_clk_i,
+  input  logic                      clu_clk_i,
+  input  logic                      rst_ni,
+  input  logic                      test_mode_i,
+  input  logic      [          1:0] boot_mode_i,
+  input  logic                      rtc_i,
   // JTAG interface
-  input  logic                 jtag_tck_i,
-  input  logic                 jtag_trst_ni,
-  input  logic                 jtag_tms_i,
-  input  logic                 jtag_tdi_i,
-  output logic                 jtag_tdo_o,
-  output logic                 jtag_tdo_oe_o,
+  input  logic                      jtag_tck_i,
+  input  logic                      jtag_trst_ni,
+  input  logic                      jtag_tms_i,
+  input  logic                      jtag_tdi_i,
+  output logic                      jtag_tdo_o,
+  output logic                      jtag_tdo_oe_o,
   // UART interface
-  output logic                 uart_tx_o,
-  input  logic                 uart_rx_i,
+  output logic                      uart_tx_o,
+  input  logic                      uart_rx_i,
   // UART modem flow control
-  output logic                 uart_rts_no,
-  output logic                 uart_dtr_no,
-  input  logic                 uart_cts_ni,
-  input  logic                 uart_dsr_ni,
-  input  logic                 uart_dcd_ni,
-  input  logic                 uart_rin_ni,
+  output logic                      uart_rts_no,
+  output logic                      uart_dtr_no,
+  input  logic                      uart_cts_ni,
+  input  logic                      uart_dsr_ni,
+  input  logic                      uart_dcd_ni,
+  input  logic                      uart_rin_ni,
   // I2C interface
-  output logic                 i2c_sda_o,
-  input  logic                 i2c_sda_i,
-  output logic                 i2c_sda_en_o,
-  output logic                 i2c_scl_o,
-  input  logic                 i2c_scl_i,
-  output logic                 i2c_scl_en_o,
+  output logic                      i2c_sda_o,
+  input  logic                      i2c_sda_i,
+  output logic                      i2c_sda_en_o,
+  output logic                      i2c_scl_o,
+  input  logic                      i2c_scl_i,
+  output logic                      i2c_scl_en_o,
   // SPI host interface
-  output logic                 spih_sck_o,
-  output logic                 spih_sck_en_o,
-  output logic [SpihNumCs-1:0] spih_csb_o,
-  output logic [SpihNumCs-1:0] spih_csb_en_o,
-  output logic [          3:0] spih_sd_o,
-  output logic [          3:0] spih_sd_en_o,
-  input  logic [          3:0] spih_sd_i,
+  output logic                      spih_sck_o,
+  output logic                      spih_sck_en_o,
+  output logic      [SpihNumCs-1:0] spih_csb_o,
+  output logic      [SpihNumCs-1:0] spih_csb_en_o,
+  output logic      [          3:0] spih_sd_o,
+  output logic      [          3:0] spih_sd_en_o,
+  input  logic      [          3:0] spih_sd_i,
   // GPIO interface
-  input  logic [         31:0] gpio_i,
-  output logic [         31:0] gpio_o,
-  output logic [         31:0] gpio_en_o
+  input  logic      [         31:0] gpio_i,
+  output logic      [         31:0] gpio_o,
+  output logic      [         31:0] gpio_en_o,
+  // APB interface
+  output apb_req_t                  apb_fll_req_o,
+  input  apb_resp_t                 apb_fll_rsp_i,
+  input  apb_resp_t                 apb_rsp_i,
+  output apb_req_t                  apb_req_o
+
 );
 
   `include "common_cells/registers.svh"
@@ -195,6 +201,37 @@ module chimera_top_wrapper
     .usb_dp_o              (),
     .usb_dp_oe_o           ()
   );
+
+  // FLL REG
+  reg_to_apb #(
+    .reg_req_t(reg_req_t),
+    .reg_rsp_t(reg_rsp_t),
+    .apb_req_t(apb_req_t),
+    .apb_rsp_t(apb_resp_t)
+  ) i_fll_reg_to_apb (
+    .clk_i    (soc_clk_i),
+    .rst_ni   (rst_ni),
+    .reg_req_i(reg_slv_req[FllIdx]),
+    .reg_rsp_o(reg_slv_rsp[FllIdx]),
+    .apb_req_o(apb_fll_req_o),
+    .apb_rsp_i(apb_fll_rsp_i)
+  );
+
+  // PADs REG
+  reg_to_apb #(
+    .reg_req_t(reg_req_t),
+    .reg_rsp_t(reg_rsp_t),
+    .apb_req_t(apb_req_t),
+    .apb_rsp_t(apb_resp_t)
+  ) i_pad_reg_to_apb (
+    .clk_i    (soc_clk_i),
+    .rst_ni   (rst_ni),
+    .reg_req_i(reg_slv_req[PadIdx]),
+    .reg_rsp_o(reg_slv_rsp[PadIdx]),
+    .apb_req_o(apb_req_o),
+    .apb_rsp_i(apb_rsp_i)
+  );
+
 
   // TOP-LEVEL REG
 

--- a/sw/include/regs/soc_ctrl.h
+++ b/sw/include/regs/soc_ctrl.h
@@ -4,7 +4,7 @@
 // Copyright 2024 ETH Zurich and University of Bologna.
 
 // Licensing information found in source file:
-// 
+//
 // SPDX-License-Identifier: SHL-0.51
 
 #ifndef _CHIMERA_REG_DEFS_
@@ -98,7 +98,7 @@ extern "C" {
 #define CHIMERA_CLUSTER_4_BUSY_CLUSTER_4_BUSY_BIT 0
 
 #ifdef __cplusplus
-}  // extern "C"
+} // extern "C"
 #endif
-#endif  // _CHIMERA_REG_DEFS_
-// End generated register defines for chimera
+#endif // _CHIMERA_REG_DEFS_
+       // End generated register defines for chimera

--- a/sw/include/soc_addr_map.h
+++ b/sw/include/soc_addr_map.h
@@ -25,3 +25,6 @@
 static uint8_t _chimera_numCores[] = {CLUSTER_0_NUMCORES, CLUSTER_1_NUMCORES, CLUSTER_2_NUMCORES,
                                       CLUSTER_3_NUMCORES, CLUSTER_4_NUMCORES};
 #define _chimera_numClusters 5
+
+#define CHIMERA_PADFRAME_BASE_ADDRESS 0x30002000
+#define FLL_BASE_ADDR 0x30003000

--- a/sw/lib/offload.c
+++ b/sw/lib/offload.c
@@ -32,6 +32,12 @@ void waitClusterBusy(uint8_t clusterId) {
 
     while (*busy_ptr == 1) {
     }
+    // TODO: temporary race condition fix
+    for (int i = 0; i < 1000; i++) {
+        // NOP
+        asm volatile("addi x0, x0, 0\n" :::);
+    }
+
     return;
 }
 

--- a/sw/tests/testMemBypass.c
+++ b/sw/tests/testMemBypass.c
@@ -15,7 +15,7 @@
 #include "offload.h"
 #include "soc_addr_map.h"
 
-//#define TOPLEVELREGION 0x30001000
+// #define TOPLEVELREGION 0x30001000
 #define NUMCLUSTERS 5
 #define TESTNARROW 0x050CCE55
 #define TESTWIDE 0x060CCE55


### PR DESCRIPTION
# ASIC
This PR adds the required logic for the Chimera PD target.

## ADD
### Hardware:
- APB ports to access external registers: padframe configuration registers and FLL registers.
### Software:
- A temporary mechanism to fix the race condition that occurs when the host offloads code before the clusters are ready (WFI).