### PR TITLE
Add clock gate peripherals

### DIFF
--- a/.gitlab/gitlab-ci.yml
+++ b/.gitlab/gitlab-ci.yml
@@ -7,7 +7,7 @@
 # We initialize the nonfree repo, then spawn a sub-pipeline from it
 
 variables:
-  VSIM_TESTS: '["testCluster", "testClusterOffload", "testMemBypass"]'
+  VSIM_TESTS: '["testCluster", "testClusterOffload", "testMemBypass", "testPeripheralsGating"]'
 
 stages:
   - nonfree

--- a/Bender.lock
+++ b/Bender.lock
@@ -69,7 +69,7 @@ packages:
     - common_cells
     - register_interface
   cheshire:
-    revision: 8aa5c40f2af14f0a40ed08ba4b24c3759ae944e5
+    revision: d91b9a4274d38a2f5f63af5404d974b794707601
     version: null
     source:
       Git: https://github.com/pulp-platform/cheshire.git
@@ -239,8 +239,8 @@ packages:
       Git: https://github.com/pulp-platform/scm.git
     dependencies: []
   serial_link:
-    revision: 5a25f5a71074f1ebb6de7b5280f2b16924bcc666
-    version: 1.1.1
+    revision: c55df03a1da06b00e567cf968b1b1a5f40c9f802
+    version: 1.1.2
     source:
       Git: https://github.com/pulp-platform/serial_link.git
     dependencies:

--- a/Bender.yml
+++ b/Bender.yml
@@ -10,7 +10,7 @@ package:
 dependencies:
   register_interface:       { git: "https://github.com/pulp-platform/register_interface.git", version: 0.4.3  }
   axi:                      { git: "https://github.com/pulp-platform/axi.git",                version: 0.39.2 }
-  cheshire:                 { git: "https://github.com/pulp-platform/cheshire.git",           rev: 8aa5c40}
+  cheshire:                 { git: "https://github.com/pulp-platform/cheshire.git",           rev: d91b9a4274d38a2f5f63af5404d974b794707601}
   snitch_cluster:           { git: "https://github.com/pulp-platform/snitch_cluster.git",     rev: c12ce9b2af1ac8edf3d4feb18939e1ad20c42225}
   common_cells:             { git: "https://github.com/pulp-platform/common_cells.git",       version: 1.31.1}
   idma:                     { git: "https://github.com/pulp-platform/iDMA.git",               rev: 9edf489f57389dce5e71252c79e337f527d3aded}

--- a/sw/tests/testPeripheralsGating.c
+++ b/sw/tests/testPeripheralsGating.c
@@ -1,0 +1,44 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Lorenzo Leone <lleone@iis.ee.ethz.ch>
+//
+// This test aims to check if the clock gating registers
+// inside Cheshire can be correctly driven from Chimera.
+// The test is not automated; each peripheral's clock
+// signal must be manually checked by looking at the waveforms.
+
+#include <stdint.h>
+#include "regs/cheshire.h"
+
+#define CHESHIRE_REGS_BASE 0x03000000
+
+int main() {
+    volatile uint32_t *regPtr = 0;
+    uint8_t expVal;
+
+    regPtr =
+        (volatile uint32_t *)(CHESHIRE_REGS_BASE + CHESHIRE_CLK_GATE_EN_PERIPHERALS_REG_OFFSET);
+
+    // |------------------------------|
+    // |        READ RST VALUE        |
+    // |------------------------------|
+    if (*regPtr != 0) return 1;
+
+    // |------------------------------|
+    // |       ENABLE CLK GATE        |
+    // |------------------------------|
+    expVal = 0x00007F;
+    *regPtr |= expVal;
+    if (*regPtr ^ expVal) return 2;
+
+    // |------------------------------|
+    // |       DISABLE CLK GATE       |
+    // |------------------------------|
+    expVal = 0x0000;
+    *regPtr &= expVal;
+    if (*regPtr ^ expVal) return 3;
+
+    return 0;
+}


### PR DESCRIPTION
# Clock Gated Peripherals
This PR aligns Chimera with the latest Cheshire version supporting clock gating logic for the internal peripherals. 

## ADDED
### Bender
Update Bender dependency to point to the correct Cheshire's revision

### SW
Add software testbench to use the clock gating logic inside Cheshire.