### PR TITLE
APB interface

### DIFF
--- a/hw/chimera_pkg.sv
+++ b/hw/chimera_pkg.sv
@@ -37,11 +37,10 @@ package chimera_pkg;
   // SoC Config
   localparam bit SnitchBootROM = 1;
   localparam bit TopLevelCfgRegs = 1;
-  localparam bit FLLCfgRegs = 1;
-  localparam bit PadCfgRegs = 1;
+  localparam bit ExtCfgRegs = 1;
 
-  // SCHEREMO: Shared Snitch bootrom, one clock gate per cluster, Fll cfg regs, Pad cfg regs
-  localparam int ExtRegNum = SnitchBootROM + TopLevelCfgRegs + FLLCfgRegs + PadCfgRegs;
+  // SCHEREMO: Shared Snitch bootrom, one clock gate per cluster, External regs (PADs, FLLs etc...)
+  localparam int ExtRegNum = SnitchBootROM + TopLevelCfgRegs + ExtCfgRegs;
   localparam int ClusterDataWidth = 64;
 
   localparam int SnitchBootROMIdx = 0;
@@ -52,15 +51,10 @@ package chimera_pkg;
   localparam doub_bt TopLevelCfgRegsRegionStart = 64'h3000_1000;
   localparam doub_bt TopLevelCfgRegsRegionEnd = 64'h3000_2000;
 
-  // PADs external configuration registers
-  localparam int PadCfgRegsIdx = 2;
-  localparam doub_bt PadCfgRegsRegionStart = 64'h3000_2000;
-  localparam doub_bt PadCfgRegsRegionEnd = 64'h3000_3000;
-
-  // FLL external configuration registers
-  localparam int FllCfgRegsIdx = 3;
-  localparam doub_bt FllCfgRegsRegionStart = 64'h3000_3000;
-  localparam doub_bt FllCfgRegsRegionEnd = 64'h3000_4000;
+  // External configuration registers: PADs, FLLs, PMU Controller
+  localparam int ExtCfgRegsIdx = 2;
+  localparam doub_bt ExtCfgRegsRegionStart = 64'h3000_2000;
+  localparam doub_bt ExtCfgRegsRegionEnd = 64'h3000_5000;
 
 
   localparam aw_bt ClusterNarrowAxiMstIdWidth = 1;
@@ -110,14 +104,9 @@ package chimera_pkg;
     cfg.RegExtNumRules = ExtRegNum;
     cfg.RegExtRegionIdx = {8'h3, 8'h2, 8'h1, 8'h0};  // SnitchBootROM
     cfg.RegExtRegionStart = {
-      FllCfgRegsRegionStart,
-      PadCfgRegsRegionStart,
-      TopLevelCfgRegsRegionStart,
-      SnitchBootROMRegionStart
+      ExtCfgRegsRegionStart, TopLevelCfgRegsRegionStart, SnitchBootROMRegionStart
     };
-    cfg.RegExtRegionEnd = {
-      FllCfgRegsRegionEnd, PadCfgRegsRegionEnd, TopLevelCfgRegsRegionEnd, SnitchBootROMRegionEnd
-    };
+    cfg.RegExtRegionEnd = {ExtCfgRegsRegionEnd, TopLevelCfgRegsRegionEnd, SnitchBootROMRegionEnd};
 
     // ACCEL HART/IRQ CFG
     cfg.NumExtIrqHarts = ExtCores;
@@ -133,8 +122,7 @@ package chimera_pkg;
 
   // To move into cheshire TYPEDEF
   localparam int unsigned RegDataWidth = 32;
-  localparam type addr_t = logic [DefaultCfg.AddrWidth-1:0];
-  // localparam type data_t = logic[DefaultCfg.AxiDataWidth];
+  localparam type addr_t = logic [ChimeraCfg[0].AddrWidth-1:0];
   localparam type data_t = logic [RegDataWidth-1:0];
   localparam type strb_t = logic [RegDataWidth/8-1:0];
 

--- a/hw/chimera_top_wrapper.sv
+++ b/hw/chimera_top_wrapper.sv
@@ -54,8 +54,6 @@ module chimera_top_wrapper
   output logic      [         31:0] gpio_o,
   output logic      [         31:0] gpio_en_o,
   // APB interface
-  output apb_req_t                  apb_fll_req_o,
-  input  apb_resp_t                 apb_fll_rsp_i,
   input  apb_resp_t                 apb_rsp_i,
   output apb_req_t                  apb_req_o
 
@@ -202,32 +200,18 @@ module chimera_top_wrapper
     .usb_dp_oe_o           ()
   );
 
-  // FLL REG
-  reg_to_apb #(
-    .reg_req_t(reg_req_t),
-    .reg_rsp_t(reg_rsp_t),
-    .apb_req_t(apb_req_t),
-    .apb_rsp_t(apb_resp_t)
-  ) i_fll_reg_to_apb (
-    .clk_i    (soc_clk_i),
-    .rst_ni   (rst_ni),
-    .reg_req_i(reg_slv_req[FllCfgRegsIdx]),
-    .reg_rsp_o(reg_slv_rsp[FllCfgRegsIdx]),
-    .apb_req_o(apb_fll_req_o),
-    .apb_rsp_i(apb_fll_rsp_i)
-  );
 
-  // PADs REG
+  // External REGs
   reg_to_apb #(
     .reg_req_t(reg_req_t),
     .reg_rsp_t(reg_rsp_t),
     .apb_req_t(apb_req_t),
     .apb_rsp_t(apb_resp_t)
-  ) i_pad_reg_to_apb (
+  ) i_ext_reg_to_apb (
     .clk_i    (soc_clk_i),
     .rst_ni   (rst_ni),
-    .reg_req_i(reg_slv_req[PadCfgRegsIdx]),
-    .reg_rsp_o(reg_slv_rsp[PadCfgRegsIdx]),
+    .reg_req_i(reg_slv_req[ExtCfgRegsIdx]),
+    .reg_rsp_o(reg_slv_rsp[ExtCfgRegsIdx]),
     .apb_req_o(apb_req_o),
     .apb_rsp_i(apb_rsp_i)
   );


### PR DESCRIPTION
# APB Interface
This PR aims to replace the multiple APB ports currently used for configuring the external PADs and FLLs configuration registers with a single shared port. This change eliminates the need to introduce additional ports for future physically aware extensions, such as adding more FLLs, PADs, or PMU controller registers.

## ADDED - HW
All _reg_bus_ requests directed outside the Chimera_SoC are now included in the same address map rule. These requests are converted into the AMBA APB protocol and routed through a single APB interface.