### PR TITLE
lleone/memisland

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -69,7 +69,7 @@ packages:
     - common_cells
     - register_interface
   cheshire:
-    revision: f28e91b4d2172c3c98ec8672a9c9225c0b45363c
+    revision: f9b9a1066143b8319c427bd790ab4729321b9f20
     version: null
     source:
       Git: https://github.com/pulp-platform/cheshire.git
@@ -87,7 +87,6 @@ packages:
     - cva6
     - idma
     - irq_router
-    - memory_island
     - opentitan_peripherals
     - register_interface
     - riscv-dbg

--- a/Bender.yml
+++ b/Bender.yml
@@ -6,15 +6,20 @@ package:
   name: chimera
   authors:
     - "Moritz Scherer <scheremo@iis.ee.ethz.ch>"
+    - "Lorenzo Leone <lleone@iis.ee.ethz.ch>"
 
 dependencies:
   register_interface:       { git: "https://github.com/pulp-platform/register_interface.git", version: 0.4.3  }
   axi:                      { git: "https://github.com/pulp-platform/axi.git",                version: 0.39.2 }
-  cheshire:                 { git: "https://github.com/pulp-platform/cheshire.git",           rev: f28e91b4d2172c3c98ec8672a9c9225c0b45363c}
+  cheshire:                 { git: "https://github.com/pulp-platform/cheshire.git",           rev: f9b9a1066143b8319c427bd790ab4729321b9f20}
   snitch_cluster:           { git: "https://github.com/pulp-platform/snitch_cluster.git",     rev: c12ce9b2af1ac8edf3d4feb18939e1ad20c42225}
   common_cells:             { git: "https://github.com/pulp-platform/common_cells.git",       version: 1.31.1}
   idma:                     { git: "https://github.com/pulp-platform/iDMA.git",               rev: 9edf489f57389dce5e71252c79e337f527d3aded}
+  memory_island:            { git: "https://github.com/pulp-platform/memory_island.git",          rev: 64828cb7a9ccc1f1656ec92d06129072f445c319 } # main branch
   apb:                      { git: "https://github.com/pulp-platform/apb.git",                version: 0.2.4          }
+
+export_include_dirs:
+  - hw/include
 
 workspace:
   package_links:
@@ -30,6 +35,7 @@ sources:
   - hw/chimera_cluster_adapter.sv
   - hw/chimera_cluster.sv
   - hw/chimera_clu_domain.sv
+  - hw/chimera_memisland_domain.sv
   - hw/chimera_top_wrapper.sv
 
   - target: any(simulation, test)

--- a/README.md
+++ b/README.md
@@ -35,16 +35,26 @@ bender checkout
 
 make chs-hw-init
 make snitch-hw-init
-make chs-sim-all
 ```
 
-To build files for modelsim:
+To regenerate software tests and libraries:
+
+`make chim-sw`
+
+This step must be executed before building the hardware to ensure the correct generation of the bootrom.
+
+To build the host device bootrom:
+
+`make chim-bootrom-init`
+
+To build Chehsire simulation files for ModelSim:
+
+`make chs-sim-all`
+
+To build Chimera simulation files for ModelSim:
 
 `make chim-sim`
 
-To regenerate software tests:
-
-`make chim-sw`
 
 ## Making Register modifications
 

--- a/chimera.mk
+++ b/chimera.mk
@@ -4,6 +4,7 @@
 #
 # Moritz Scherer <scheremo@iis.ee.ethz.ch>
 
+
 CLINTCORES = 46
 PLICCORES = 92
 PLIC_NUM_INTRS = 92
@@ -17,9 +18,11 @@ update_plic: $(CHS_ROOT)/hw/rv_plic.cfg.hjson
 gen_idma_hw:
 	make -C $(IDMA_ROOT) idma_hw_all
 
+CHS_SW_LD_DIR = $(CHIM_ROOT)/sw/link
+
 .PHONY: chs-hw-init
-chs-hw-init: update_plic gen_idma_hw
-	make -B chs-hw-all CHS_XLEN=$(CHS_XLEN)
+chs-hw-init: update_plic gen_idma_hw $(CHIM_SW_LIB)
+	make -B chs-hw-all CHS_XLEN=$(CHS_XLEN) CHS_SW_LD_DIR=$(CHS_SW_LD_DIR)
 
 .PHONY: snitch-hw-init
 snitch-hw-init:
@@ -73,8 +76,11 @@ chim-nonfree-init:
 
 -include $(CHIM_ROOT)/bender.mk
 
-# Include subdir Makefiles
+# Necessary to build libchimera.a for bootrom.elf
+# TODO: Here the make chim-sw cannot work properly FIND SOLUTION !!!!!
 -include $(CHIM_ROOT)/sw/sw.mk
+
+# Include subdir Makefiles
 -include $(CHIM_ROOT)/utils/utils.mk
 # Include target makefiles
 -include $(CHIM_ROOT)/target/sim/sim.mk

--- a/hw/chimera_clu_domain.sv
+++ b/hw/chimera_clu_domain.sv
@@ -15,62 +15,62 @@ module chimera_clu_domain
   import chimera_pkg::*;
   import cheshire_pkg::*;
 #(
-  parameter cheshire_cfg_t Cfg               = '0,
-  parameter type           narrow_in_req_t   = logic,
-  parameter type           narrow_in_resp_t  = logic,
-  parameter type           narrow_out_req_t  = logic,
-  parameter type           narrow_out_resp_t = logic,
-  parameter type           wide_out_req_t    = logic,
-  parameter type           wide_out_resp_t   = logic
+  parameter chimera_cfg_t Cfg               = '0,
+  parameter type          narrow_in_req_t   = logic,
+  parameter type          narrow_in_resp_t  = logic,
+  parameter type          narrow_out_req_t  = logic,
+  parameter type          narrow_out_resp_t = logic,
+  parameter type          wide_out_req_t    = logic,
+  parameter type          wide_out_resp_t   = logic
 ) (
-  input  logic                                                       soc_clk_i,
-  input  logic             [                        ExtClusters-1:0] clu_clk_i,
-  input  logic             [                        ExtClusters-1:0] rst_sync_ni,
-  input  logic             [                        ExtClusters-1:0] widemem_bypass_i,
+  input  logic                                                              soc_clk_i,
+  input  logic             [                               ExtClusters-1:0] clu_clk_i,
+  input  logic             [                               ExtClusters-1:0] rst_sync_ni,
+  input  logic             [                               ExtClusters-1:0] widemem_bypass_i,
   //-----------------------------
   // Interrupt ports
   //-----------------------------
-  input  logic             [iomsb(NumIrqCtxts*Cfg.NumExtIrqHarts):0] xeip_i,
-  input  logic             [            iomsb(Cfg.NumExtIrqHarts):0] mtip_i,
-  input  logic             [            iomsb(Cfg.NumExtIrqHarts):0] msip_i,
-  input  logic             [            iomsb(Cfg.NumExtDbgHarts):0] debug_req_i,
+  input  logic             [iomsb(NumIrqCtxts*Cfg.ChsCfg.NumExtIrqHarts):0] xeip_i,
+  input  logic             [            iomsb(Cfg.ChsCfg.NumExtIrqHarts):0] mtip_i,
+  input  logic             [            iomsb(Cfg.ChsCfg.NumExtIrqHarts):0] msip_i,
+  input  logic             [            iomsb(Cfg.ChsCfg.NumExtDbgHarts):0] debug_req_i,
   //-----------------------------
   // Narrow AXI ports
   //-----------------------------
-  input  narrow_in_req_t   [              iomsb(Cfg.AxiExtNumSlv):0] narrow_in_req_i,
-  output narrow_in_resp_t  [              iomsb(Cfg.AxiExtNumSlv):0] narrow_in_resp_o,
-  output narrow_out_req_t  [              iomsb(Cfg.AxiExtNumMst):0] narrow_out_req_o,
-  input  narrow_out_resp_t [              iomsb(Cfg.AxiExtNumMst):0] narrow_out_resp_i,
+  input  narrow_in_req_t   [                               ExtClusters-1:0] narrow_in_req_i,
+  output narrow_in_resp_t  [                               ExtClusters-1:0] narrow_in_resp_o,
+  output narrow_out_req_t  [              iomsb(Cfg.ChsCfg.AxiExtNumMst):0] narrow_out_req_o,
+  input  narrow_out_resp_t [              iomsb(Cfg.ChsCfg.AxiExtNumMst):0] narrow_out_resp_i,
   //-----------------------------
   // Wide AXI ports
   //-----------------------------
-  output wide_out_req_t    [          iomsb(Cfg.AxiExtNumWideMst):0] wide_out_req_o,
-  input  wide_out_resp_t   [          iomsb(Cfg.AxiExtNumWideMst):0] wide_out_resp_i,
+  output wide_out_req_t    [          iomsb(Cfg.ChsCfg.AxiExtNumWideMst):0] wide_out_req_o,
+  input  wide_out_resp_t   [          iomsb(Cfg.ChsCfg.AxiExtNumWideMst):0] wide_out_resp_i,
   //-----------------------------
   // Isolation control ports
   //-----------------------------
-  input  logic             [                        ExtClusters-1:0] isolate_i,
-  output logic             [                        ExtClusters-1:0] isolate_o
+  input  logic             [                               ExtClusters-1:0] isolate_i,
+  output logic             [                               ExtClusters-1:0] isolate_o
 );
 
   // Axi parameters
-  localparam int unsigned AxiWideDataWidth = Cfg.AxiDataWidth * Cfg.MemIslNarrowToWideFactor;
+  localparam int unsigned AxiWideDataWidth = Cfg.ChsCfg.AxiDataWidth * Cfg.MemIslNarrowToWideFactor;
   localparam int unsigned AxiWideSlvIdWidth = Cfg.MemIslAxiMstIdWidth + $clog2(Cfg.MemIslWidePorts);
-  localparam int unsigned AxiSlvIdWidth = Cfg.AxiMstIdWidth + $clog2(
+  localparam int unsigned AxiSlvIdWidth = Cfg.ChsCfg.AxiMstIdWidth + $clog2(
       cheshire_pkg::gen_axi_in(Cfg).num_in
   );
 
   // Isolated AXI signals
-  narrow_in_req_t   [    iomsb(Cfg.AxiExtNumSlv):0] narrow_in_isolated_req;
-  narrow_in_resp_t  [    iomsb(Cfg.AxiExtNumSlv):0] narrow_in_isolated_resp;
-  narrow_out_req_t  [    iomsb(Cfg.AxiExtNumMst):0] narrow_out_isolated_req;
-  narrow_out_resp_t [    iomsb(Cfg.AxiExtNumMst):0] narrow_out_isolated_resp;
-  wide_out_req_t    [iomsb(Cfg.AxiExtNumWideMst):0] wide_out_isolated_req;
-  wide_out_resp_t   [iomsb(Cfg.AxiExtNumWideMst):0] wide_out_isolated_resp;
+  narrow_in_req_t   [    iomsb(Cfg.ChsCfg.AxiExtNumSlv):0] narrow_in_isolated_req;
+  narrow_in_resp_t  [    iomsb(Cfg.ChsCfg.AxiExtNumSlv):0] narrow_in_isolated_resp;
+  narrow_out_req_t  [    iomsb(Cfg.ChsCfg.AxiExtNumMst):0] narrow_out_isolated_req;
+  narrow_out_resp_t [    iomsb(Cfg.ChsCfg.AxiExtNumMst):0] narrow_out_isolated_resp;
+  wide_out_req_t    [iomsb(Cfg.ChsCfg.AxiExtNumWideMst):0] wide_out_isolated_req;
+  wide_out_resp_t   [iomsb(Cfg.ChsCfg.AxiExtNumWideMst):0] wide_out_isolated_resp;
 
-  logic             [    iomsb(Cfg.AxiExtNumSlv):0] isolated_narrow_in;
-  logic             [    iomsb(Cfg.AxiExtNumMst):0] isolated_narrow_out;
-  logic             [iomsb(Cfg.AxiExtNumWideMst):0] isolated_wide_out;
+  logic             [    iomsb(Cfg.ChsCfg.AxiExtNumSlv):0] isolated_narrow_in;
+  logic             [    iomsb(Cfg.ChsCfg.AxiExtNumMst):0] isolated_narrow_out;
+  logic             [iomsb(Cfg.ChsCfg.AxiExtNumWideMst):0] isolated_wide_out;
 
 
 
@@ -79,13 +79,13 @@ module chimera_clu_domain
     if (IsolateClusters == 1) begin : gen_cluster_iso
       // Add AXI isolation at the Narrow Input Interface
       axi_isolate #(
-        .NumPending          (Cfg.AxiMaxSlvTrans),
+        .NumPending          (Cfg.ChsCfg.AxiMaxSlvTrans),
         .TerminateTransaction(0),
         .AtopSupport         (1),
-        .AxiAddrWidth        (Cfg.AddrWidth),
-        .AxiDataWidth        (Cfg.AxiDataWidth),
+        .AxiAddrWidth        (Cfg.ChsCfg.AddrWidth),
+        .AxiDataWidth        (Cfg.ChsCfg.AxiDataWidth),
         .AxiIdWidth          (AxiSlvIdWidth),
-        .AxiUserWidth        (Cfg.AxiUserWidth),
+        .AxiUserWidth        (Cfg.ChsCfg.AxiUserWidth),
         .axi_req_t           (narrow_in_req_t),
         .axi_resp_t          (narrow_in_resp_t)
       ) i_iso_narrow_in_cluster (
@@ -107,13 +107,13 @@ module chimera_clu_domain
           narrowOutIdx++
       ) begin : gen_iso_narrow_out
         axi_isolate #(
-          .NumPending          (Cfg.AxiMaxSlvTrans),
+          .NumPending          (Cfg.ChsCfg.AxiMaxSlvTrans),
           .TerminateTransaction(0),
           .AtopSupport         (1),
-          .AxiAddrWidth        (Cfg.AddrWidth),
-          .AxiDataWidth        (Cfg.AxiDataWidth),
-          .AxiIdWidth          (Cfg.AxiMstIdWidth),
-          .AxiUserWidth        (Cfg.AxiUserWidth),
+          .AxiAddrWidth        (Cfg.ChsCfg.AddrWidth),
+          .AxiDataWidth        (Cfg.ChsCfg.AxiDataWidth),
+          .AxiIdWidth          (Cfg.ChsCfg.AxiMstIdWidth),
+          .AxiUserWidth        (Cfg.ChsCfg.AxiUserWidth),
           .axi_req_t           (narrow_out_req_t),
           .axi_resp_t          (narrow_out_resp_t)
         ) i_iso_narrow_out_cluster (
@@ -130,13 +130,13 @@ module chimera_clu_domain
 
       // Add AXI isolation at the Wide Interface
       axi_isolate #(
-        .NumPending          (Cfg.AxiMaxSlvTrans),
+        .NumPending          (Cfg.ChsCfg.AxiMaxSlvTrans),
         .TerminateTransaction(0),
         .AtopSupport         (1),
-        .AxiAddrWidth        (Cfg.AddrWidth),
+        .AxiAddrWidth        (Cfg.ChsCfg.AddrWidth),
         .AxiDataWidth        (AxiWideDataWidth),
-        .AxiIdWidth          (Cfg.MemIslAxiMstIdWidth),  // To Check
-        .AxiUserWidth        (Cfg.AxiUserWidth),
+        .AxiIdWidth          (Cfg.MemIslAxiMstIdWidth),    // To Check
+        .AxiUserWidth        (Cfg.ChsCfg.AxiUserWidth),
         .axi_req_t           (wide_out_req_t),
         .axi_resp_t          (wide_out_resp_t)
       ) i_iso_wide_cluster (
@@ -191,7 +191,7 @@ module chimera_clu_domain
       .mtip_i             (mtip_i[`PREVNRCORES(extClusterIdx)+:`NRCORES(extClusterIdx)]),
       .msip_i             (msip_i[`PREVNRCORES(extClusterIdx)+:`NRCORES(extClusterIdx)]),
       .hart_base_id_i     (10'(`PREVNRCORES(extClusterIdx) + 1)),
-      .cluster_base_addr_i(Cfg.AxiExtRegionStart[extClusterIdx][Cfg.AddrWidth-1:0]),
+      .cluster_base_addr_i(Cfg.ChsCfg.AxiExtRegionStart[extClusterIdx][Cfg.ChsCfg.AddrWidth-1:0]),
       .boot_addr_i        (SnitchBootROMRegionStart[31:0]),
 
       .narrow_in_req_i  (narrow_in_isolated_req[extClusterIdx]),

--- a/hw/chimera_memisland_domain.sv
+++ b/hw/chimera_memisland_domain.sv
@@ -1,0 +1,83 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Lorenzo Leone <lleone@iis.ee.ethz.ch>
+
+module chimera_memisland_domain
+  import chimera_pkg::*;
+  import cheshire_pkg::*;
+#(
+  parameter chimera_cfg_t Cfg              = '0,
+  parameter int unsigned  NumWideMst       = '0,
+  parameter type          axi_narrow_req_t = logic,
+  parameter type          axi_narrow_rsp_t = logic,
+  parameter type          axi_wide_req_t   = logic,
+  parameter type          axi_wide_rsp_t   = logic
+) (
+  input  logic                             clk_i,
+  input  logic                             rst_ni,
+  input  axi_narrow_req_t                  axi_narrow_req_i,
+  output axi_narrow_rsp_t                  axi_narrow_rsp_o,
+  input  axi_wide_req_t   [NumWideMst-1:0] axi_wide_req_i,
+  output axi_wide_rsp_t   [NumWideMst-1:0] axi_wide_rsp_o
+);
+
+  // Define needed parameters
+  localparam axi_in_t AxiIn = gen_axi_in(Cfg.ChsCfg);  // lleone: TODO: find a better solution
+  localparam int unsigned AxiSlvIdWidth = Cfg.ChsCfg.AxiMstIdWidth + $clog2(AxiIn.num_in);
+  localparam int unsigned WideSlaveIdWidth = $clog2(Cfg.MemIslWidePorts);
+  localparam int unsigned WideDataWidth = Cfg.ChsCfg.AxiDataWidth * Cfg.MemIslNarrowToWideFactor;
+
+  axi_narrow_req_t axi_memory_island_amo_req;
+  axi_narrow_rsp_t axi_memory_island_amo_rsp;
+
+  axi_riscv_atomics_structs #(
+    .AxiAddrWidth(Cfg.ChsCfg.AddrWidth),
+    .AxiDataWidth(Cfg.ChsCfg.AxiDataWidth),
+    .AxiIdWidth(AxiSlvIdWidth),  // lleone: TODO: solve issue wiyth declaration on top
+    .AxiUserWidth(Cfg.ChsCfg.AxiUserWidth),
+    .AxiMaxReadTxns(Cfg.ChsCfg.LlcMaxReadTxns),
+    .AxiMaxWriteTxns(Cfg.ChsCfg.LlcMaxWriteTxns),
+    .AxiUserAsId(1),
+    .AxiUserIdMsb(Cfg.ChsCfg.AxiUserAmoMsb),
+    .AxiUserIdLsb(Cfg.ChsCfg.AxiUserAmoLsb),
+    .RiscvWordWidth(riscv::XLEN),
+    .NAxiCuts(Cfg.ChsCfg.LlcAmoNumCuts),
+    .axi_req_t(axi_narrow_req_t),
+    .axi_rsp_t(axi_narrow_rsp_t)
+  ) i_memory_island_atomics (
+    .clk_i        (clk_i),
+    .rst_ni,
+    .axi_slv_req_i(axi_narrow_req_i),
+    .axi_slv_rsp_o(axi_narrow_rsp_o),
+    .axi_mst_req_o(axi_memory_island_amo_req),
+    .axi_mst_rsp_i(axi_memory_island_amo_rsp)
+  );
+
+  axi_memory_island_wrap #(
+    .AddrWidth(Cfg.ChsCfg.AddrWidth),
+    .NarrowDataWidth(Cfg.ChsCfg.AxiDataWidth),
+    .WideDataWidth(WideDataWidth),
+    .AxiNarrowIdWidth(AxiSlvIdWidth),  // lleone: TODO: solve issue wiyth declaration on top
+    .AxiWideIdWidth(WideSlaveIdWidth),
+    .axi_narrow_req_t(axi_narrow_req_t),
+    .axi_narrow_rsp_t(axi_narrow_rsp_t),
+    .axi_wide_req_t(axi_wide_req_t),
+    .axi_wide_rsp_t(axi_wide_rsp_t),
+    .NumNarrowReq(Cfg.MemIslNarrowPorts),
+    .NumWideReq(Cfg.MemIslWidePorts),
+    .NumWideBanks(Cfg.MemIslNumWideBanks),
+    .NarrowExtraBF(1),
+    .WordsPerBank(Cfg.MemIslWordsPerBank)
+  ) i_memory_island (
+    .clk_i           (clk_i),
+    .rst_ni,
+    .axi_narrow_req_i(axi_memory_island_amo_req),
+    .axi_narrow_rsp_o(axi_memory_island_amo_rsp),
+    // SCHEREMO: TODO: Demux wide accesses to go over narrow ports iff address not in memory island range
+    .axi_wide_req_i  (axi_wide_req_i),
+    .axi_wide_rsp_o  (axi_wide_rsp_o)
+  );
+
+endmodule : chimera_memisland_domain

--- a/hw/include/chimera/typedef.svh
+++ b/hw/include/chimera/typedef.svh
@@ -1,0 +1,31 @@
+// Copyright 2022 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Moritz Scherer <scheremo@iis.ee.ethz.ch>
+
+`ifndef CHIMERA_TYPEDEF_SVH_
+`define CHIMERA_TYPEDEF_SVH_
+
+`include "axi/typedef.svh"
+`include "register_interface/typedef.svh"
+`include "cheshire/typedef.svh"
+
+`define CHIMERA_TYPEDEF_MEMORYISLAND_WIDE(__prefix, __cfg) \
+  localparam type __prefix``addr_t = logic [__cfg.ChsCfg.AddrWidth-1:0]; \
+  localparam int wideDataWidth = __cfg.ChsCfg.AxiDataWidth*__cfg.MemIslNarrowToWideFactor; \
+  localparam type __prefix``_axi_data_t    = logic [wideDataWidth   -1:0]; \
+  localparam type __prefix``_axi_strb_t    = logic [wideDataWidth/8 -1:0]; \
+  localparam type __prefix``_axi_user_t    = logic [__cfg.ChsCfg.AxiUserWidth   -1:0]; \
+  localparam type __prefix``_axi_mst_id_t  = logic [__cfg.MemIslAxiMstIdWidth-1:0]; \
+  localparam type __prefix``_axi_slv_id_t  = logic [__cfg.MemIslAxiMstIdWidth + $clog2(__cfg.MemIslWidePorts)-1:0]; \
+  `CHESHIRE_TYPEDEF_AXI_CT(__prefix``_axi_mst, __prefix``addr_t, \
+      __prefix``_axi_mst_id_t, __prefix``_axi_data_t, __prefix``_axi_strb_t, __prefix``_axi_user_t) \
+  `CHESHIRE_TYPEDEF_AXI_CT(__prefix``_axi_slv, __prefix``addr_t, \
+      __prefix``_axi_slv_id_t, __prefix``_axi_data_t, __prefix``_axi_strb_t, __prefix``_axi_user_t) \
+
+// Note that the prefix does *not* include a leading underscore.
+`define CHIMERA_TYPEDEF_ALL(__prefix, __cfg) \
+  `CHIMERA_TYPEDEF_MEMORYISLAND_WIDE(mem_isl_wide, __cfg)
+
+`endif

--- a/sw/link/common.ldh
+++ b/sw/link/common.ldh
@@ -1,0 +1,55 @@
+/* Copyright 2022 ETH Zurich and University of Bologna. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/* Nicole Narr <narrn@student.ethz.ch> */
+/* Christopher Reinwardt <creinwar@student.ethz.ch> */
+/* Paul Scheffler <paulsc@iis.ee.ethz.ch> */
+
+/* This header defines symbols and rules universal to bare-metal execution */
+
+ENTRY(_start)
+
+MEMORY {
+  bootrom (rx)  : ORIGIN = 0x02000000, LENGTH = 16K
+  /* We assume at least 64 KiB SPM, same minus stack for ROMs. */
+  /* If more SPM is available, CRT0 repoints the stack. */
+  extrom (rx)   : ORIGIN = 0x00000000, LENGTH = 48K
+  spm (rwx)     : ORIGIN = 0x10000000, LENGTH = 64K
+  memisl (rwx)    : ORIGIN = 0x48000000, LENGTH = 64K
+  /* We  assume at least 8 MiB of DRAM (minimum for Linux). */
+  dram (rwx)    : ORIGIN = 0x80000000, LENGTH = 8M
+}
+
+SECTIONS {
+  /* Keep binaries lean */
+  /DISCARD/ : { *(.riscv.attributes) *(.comment) }
+
+  /* Global and stack pointer */
+  /* By default, keep the calling context (boot ROM) stack pointer */
+  __global_pointer$ = ADDR(.misc) + SIZEOF(.misc) / 2;
+  __stack_pointer$  = 0;
+
+  /* Further addresses */
+  __base_dma      = 0x01000000;
+  __base_bootrom  = 0x02000000;
+  __base_clint    = 0x02040000;
+  __base_axirt    = 0x020C0000;
+  __base_axirtgrd = 0x020C1ffc;
+  __base_regs     = 0x03000000;
+  __base_llc      = 0x03001000;
+  __base_uart     = 0x03002000;
+  __base_i2c      = 0x03003000;
+  __base_spih     = 0x03004000;
+  __base_gpio     = 0x03005000;
+  __base_slink    = 0x03006000;
+  __base_vga      = 0x03007000;
+  __base_usb      = 0x03008000;
+  __base_bus_err  = 0x03009000;
+  __base_plic     = 0x04000000;
+  __base_clic     = 0x08000000;
+  __base_spm      = ORIGIN(spm);
+  __base_dram     = ORIGIN(dram);
+  __base_memisl   = ORIGIN(memisl);
+  __stack_start   = ORIGIN(memisl) + LENGTH(memisl);
+}

--- a/sw/link/memisl.ld
+++ b/sw/link/memisl.ld
@@ -1,0 +1,46 @@
+/* Copyright 2022 ETH Zurich and University of Bologna. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/* Nicole Narr <narrn@student.ethz.ch> */
+/* Christopher Reinwardt <creinwar@student.ethz.ch> */
+/* Paul Scheffler <paulsc@iis.ee.ethz.ch> */
+/* Lorenzo Leone <lleone@iis.ee.ethz.ch> */
+
+
+INCLUDE common.ldh
+
+SECTIONS {
+  .text : {
+    *(.text._start)
+    *(.text)
+    *(.text.*)
+  } > memisl
+
+  .misc : ALIGN(16) {
+    *(.rodata)
+    *(.rodata.*)
+    *(.data)
+    *(.data.*)
+    *(.srodata)
+    *(.srodata.*)
+    *(.sdata)
+    *(.sdata.*)
+  } > memisl
+
+  . = ALIGN(32);
+  __bss_start = .;
+  .bss : {
+    *(.bss)
+    *(.bss.*)
+    *(.sbss)
+    *(.sbss.*)
+  } > memisl
+  . = ALIGN(32);
+  __bss_end = .;
+
+  .bulk : ALIGN(16) {
+    *(.bulk)
+    *(.bulk.*)
+  } > memisl
+}

--- a/sw/sw.mk
+++ b/sw/sw.mk
@@ -8,7 +8,13 @@ ifndef chim_sw_mk
 chim_sw_mk=1
 
 CHS_SW_INCLUDES += -I$(CHIM_SW_DIR)/include
+
+
+# SCHEREMO: use im for platform-level SW, as the smallest common denominator between CVA6 and the Snitch cluster.
+# CVA6's bootrom however needs imc, so override that for this specific case.
 CHS_SW_FLAGS += -falign-functions=64 -march=rv32im
+CHS_BROM_FLAGS += -march=rv32imc
+
 CHS_SW_LDFLAGS += -L$(CHIM_SW_DIR)/lib
 
 CHIM_SW_LIB_SRCS_C  = $(wildcard $(CHIM_SW_DIR)/lib/*.c $(CHIM_SW_DIR)/lib/**/*.c)
@@ -27,9 +33,30 @@ CHIM_SW_TEST_SRCS_C     	= $(wildcard $(CHIM_SW_DIR)/tests/*.c)
 
 CHIM_SW_TEST_MEMISL_DUMP = $(CHIM_SW_TEST_SRCS_S:.S=.memisl.dump)  $(CHIM_SW_TEST_SRCS_C:.c=.memisl.dump)
 
-CHIM_SW_TESTS += $(CHIM_SW_TEST_DRAM_DUMP) $(CHIM_SW_TEST_SPM_DUMP) $(CHIM_SW_TEST_MEMISL_DUMP) $(CHIM_SW_TEST_SPM_ROMH) $(CHIM_SW_TEST_SPM_GPTH)
+CHIM_SW_TESTS += $(CHIM_SW_TEST_MEMISL_DUMP)
+
+# All objects require up-to-date patches and headers
+%.o: %.c
+	$(CHS_SW_CC) $(CHS_SW_INCLUDES) $(CHS_SW_CCFLAGS) -c $< -o $@
+
+%.o: %.S
+	$(CHS_SW_CC) $(CHS_SW_INCLUDES) $(CHS_SW_CCFLAGS) -c $< -o $@
+
+define chim_sw_ld_elf_rule
+.PRECIOUS: %.$(1).elf
+
+%.$(1).elf: $$(CHS_SW_LD_DIR)/$(1).ld %.o $$(CHS_SW_LIBS)
+	$$(CHS_SW_CC) $$(CHS_SW_INCLUDES) -T$$< $$(CHS_SW_LDFLAGS) -o $$@ $$*.o $$(CHS_SW_LIBS)
+endef
+
+$(foreach link,$(patsubst $(CHS_SW_LD_DIR)/%.ld,%,$(wildcard $(CHS_SW_LD_DIR)/*.ld)),$(eval $(call chim_sw_ld_elf_rule,$(link))))
 
 chim-sw: $(CHIM_SW_LIB) $(CHIM_SW_TESTS)
+
+.PHONY: chim-bootrom-init
+chim-bootrom-init: chs-hw-init chim-sw
+	make -B chs-bootrom-all CHS_XLEN=$(CHS_XLEN) CHS_SW_LD_DIR=$(CHS_SW_LD_DIR)
+
 
 chim-sw-clean:
 	@find sw/tests | grep ".*\.elf" | xargs -I ! rm !

--- a/target/sim/src/fixture_chimera_soc.sv
+++ b/target/sim/src/fixture_chimera_soc.sv
@@ -13,15 +13,17 @@ module fixture_chimera_soc #(
 );
 
   `include "cheshire/typedef.svh"
+  `include "chimera/typedef.svh"
 
   import cheshire_pkg::*;
   import tb_cheshire_pkg::*;
   import chimera_pkg::*;
 
-  localparam cheshire_cfg_t DutCfg = ChimeraCfg[SelectedCfg];
+  localparam chimera_cfg_t DutCfg = ChimeraCfg[SelectedCfg];
+  localparam cheshire_cfg_t ChsCfg = DutCfg.ChsCfg;
 
-  `CHESHIRE_TYPEDEF_ALL(, DutCfg)
-
+  `CHESHIRE_TYPEDEF_ALL(, ChsCfg)
+  `CHIMERA_TYPEDEF_ALL(, DutCfg)
 
   ///////////
   //  DUT  //
@@ -121,7 +123,7 @@ module fixture_chimera_soc #(
   ///////////
 
   vip_chimera_soc #(
-    .DutCfg           (DutCfg),
+    .DutCfg           (ChsCfg),
     .axi_ext_mst_req_t(axi_mst_req_t),
     .axi_ext_mst_rsp_t(axi_mst_rsp_t)
   ) vip (

--- a/target/sim/src/tb_chimera_pkg.sv
+++ b/target/sim/src/tb_chimera_pkg.sv
@@ -7,36 +7,32 @@
 /// This package contains parameters used in the simulation environment
 package tb_chimera_pkg;
 
+  import chimera_pkg::*;
   import cheshire_pkg::*;
 
   // A dedicated RT config
-  function automatic cheshire_cfg_t gen_cheshire_rt_cfg();
-    cheshire_cfg_t ret = DefaultCfg;
-    ret.AxiRt = 1;
+  function automatic chimera_cfg_t gen_cheshire_rt_cfg();
+    cheshire_cfg_t ChsCfg = DefaultCfg;
+    chimera_cfg_t  ret;
+    ret.ChsCfg.AxiRt = 1;
     return ret;
   endfunction
 
   // An embedded 32 bit config
-  function automatic cheshire_cfg_t gen_cheshire_emb_cfg();
-    cheshire_cfg_t ret = DefaultCfg;
-    ret.Vga          = 0;
-    ret.SerialLink   = 0;
-    ret.AxiUserWidth = 64;
+  function automatic chimera_cfg_t gen_cheshire_emb_cfg();
+    cheshire_cfg_t ChsCfg = DefaultCfg;
+    chimera_cfg_t  ret;
+    ret.ChsCfg.Vga          = 0;
+    ret.ChsCfg.SerialLink   = 0;
+    ret.ChsCfg.AxiUserWidth = 64;
     return ret;
   endfunction : gen_cheshire_emb_cfg
 
-  function automatic cheshire_cfg_t gen_cheshire_memisl_cfg();
-    cheshire_cfg_t ret = gen_cheshire_emb_cfg();
-    ret.MemoryIsland = 1;
-    return ret;
-  endfunction : gen_cheshire_memisl_cfg
-
   // Number of Cheshire configurations
-  localparam int unsigned NumCheshireConfigs = 32'd4;
+  localparam int unsigned NumCheshireConfigs = 32'd3;
 
   // Assemble a configuration array indexed by a numeric parameter
-  localparam cheshire_cfg_t [NumCheshireConfigs-1:0] TbCheshireConfigs = {
-    gen_cheshire_memisl_cfg(),  // 3: Embedded + Memory Island configuration
+  localparam chimera_cfg_t [NumCheshireConfigs-1:0] TbCheshireConfigs = {
     gen_cheshire_emb_cfg(),  // 2: Embedded configuration
     gen_cheshire_rt_cfg(),  // 1: RT-enabled configuration
     DefaultCfg  // 0: Default configuration


### PR DESCRIPTION
# Memory Island Integration
This PR relocates the Memory Island IP from Cheshire and integrates it into the Chimera SoC module. The goal is to isolate the memory into a separate domain, allowing it to be managed independently from the power domain perspective.

## Added
### HW:
- **chimera_memisland_domain:** This module represents the memory domain and will be used in the PMU as an internal Power Domain of the Chimera SoC.
- **chimera_cfg_t:** Since the memory island is now external to Cheshire, a new structure has been created inside _chimera_pkg_ to include Cheshire's configuration struct along with the memory island information. As a result, all hardware modules and testbench files have been adapted to accommodate the new configuration type.
### SW:
- **CHS_SW_LD_DIR:** This flag has been introduced in the software stack to build Cheshire's bootrom according to Chimera’s memory map, which now includes the memory island. It is the directory where the compiler can find the necessary linker scripts.
