### PR TITLE
CVA6 PLEN fix

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -60,8 +60,8 @@ packages:
     dependencies:
     - common_cells
   axi_vga:
-    revision: 3718b9930f94a9eaad8ee50b4bccc71df0403084
-    version: 0.1.3
+    revision: 4d3e70d4f47bb74edc1ab68d99ffc02382e0fb9e
+    version: 0.1.4
     source:
       Git: https://github.com/pulp-platform/axi_vga.git
     dependencies:
@@ -69,7 +69,7 @@ packages:
     - common_cells
     - register_interface
   cheshire:
-    revision: d91b9a4274d38a2f5f63af5404d974b794707601
+    revision: f28e91b4d2172c3c98ec8672a9c9225c0b45363c
     version: null
     source:
       Git: https://github.com/pulp-platform/cheshire.git
@@ -141,7 +141,7 @@ packages:
       Git: https://github.com/pulp-platform/common_verification.git
     dependencies: []
   cva6:
-    revision: 637a0e6cbc8ec395c4bb4f54ee9dc1110d3fb1ac
+    revision: 630bd959c9cc69a35d461a2abc205310d2edacf8
     version: null
     source:
       Git: https://github.com/Scheremo/cva6.git
@@ -215,8 +215,8 @@ packages:
     - register_interface
     - tech_cells_generic
   register_interface:
-    revision: ae616e5a1ec2b41e72d200e5ab09c65e94aebd3d
-    version: 0.4.4
+    revision: 5daa85d164cf6b54ad061ea1e4c6f3624556e467
+    version: 0.4.5
     source:
       Git: https://github.com/pulp-platform/register_interface.git
     dependencies:

--- a/Bender.yml
+++ b/Bender.yml
@@ -10,7 +10,7 @@ package:
 dependencies:
   register_interface:       { git: "https://github.com/pulp-platform/register_interface.git", version: 0.4.3  }
   axi:                      { git: "https://github.com/pulp-platform/axi.git",                version: 0.39.2 }
-  cheshire:                 { git: "https://github.com/pulp-platform/cheshire.git",           rev: d91b9a4274d38a2f5f63af5404d974b794707601}
+  cheshire:                 { git: "https://github.com/pulp-platform/cheshire.git",           rev: f28e91b4d2172c3c98ec8672a9c9225c0b45363c}
   snitch_cluster:           { git: "https://github.com/pulp-platform/snitch_cluster.git",     rev: c12ce9b2af1ac8edf3d4feb18939e1ad20c42225}
   common_cells:             { git: "https://github.com/pulp-platform/common_cells.git",       version: 1.31.1}
   idma:                     { git: "https://github.com/pulp-platform/iDMA.git",               rev: 9edf489f57389dce5e71252c79e337f527d3aded}


### PR DESCRIPTION
This PR updates the cheshire dependency, which updates the CVA6 dependency, which now configures the address translation between virtual addresses and physical addresses to use the same VLEN and PLEN if there is no MMU instantiated.