### PR TITLE
Lleone/cfg param

### DIFF
--- a/hw/chimera_clu_domain.sv
+++ b/hw/chimera_clu_domain.sv
@@ -76,7 +76,7 @@ module chimera_clu_domain
 
   for (genvar extClusterIdx = 0; extClusterIdx < ExtClusters; extClusterIdx++) begin : gen_clusters
 
-    if (IsolateClusters == 1) begin : gen_cluster_iso
+    if (Cfg.IsolateClusters == 1) begin : gen_cluster_iso
       // Add AXI isolation at the Narrow Input Interface
       axi_isolate #(
         .NumPending          (Cfg.ChsCfg.AxiMaxSlvTrans),

--- a/hw/chimera_top_wrapper.sv
+++ b/hw/chimera_top_wrapper.sv
@@ -9,7 +9,7 @@ module chimera_top_wrapper
   import chimera_pkg::*;
   import chimera_reg_pkg::*;
 #(
-  parameter int unsigned SelectedCfg = 0
+  parameter chimera_cfg_t Cfg = '0
 ) (
   input  logic                        soc_clk_i,
   input  logic                        clu_clk_i,
@@ -70,7 +70,6 @@ module chimera_top_wrapper
   `include "chimera/typedef.svh"
 
   // Cheshire config
-  localparam chimera_cfg_t Cfg = ChimeraCfg[SelectedCfg];
   localparam cheshire_cfg_t ChsCfg = Cfg.ChsCfg;
 
   `CHESHIRE_TYPEDEF_ALL(, ChsCfg)
@@ -340,8 +339,8 @@ module chimera_top_wrapper
     .xeip_i           (xeip_ext),
     .mtip_i           (mtip_ext),
     .msip_i           (msip_ext),
-    .narrow_in_req_i  (axi_slv_req[ExtClustersBaseIdx+:ExtClusters]),
-    .narrow_in_resp_o (axi_slv_rsp[ExtClustersBaseIdx+:ExtClusters]),
+    .narrow_in_req_i  (axi_slv_req[ClusterIdx[0]+:ExtClusters]),
+    .narrow_in_resp_o (axi_slv_rsp[ClusterIdx[0]+:ExtClusters]),
     .narrow_out_req_o (axi_mst_req),
     .narrow_out_resp_i(axi_mst_rsp),
     .wide_out_req_o   (axi_wide_mst_req),

--- a/target/sim/src/fixture_chimera_soc.sv
+++ b/target/sim/src/fixture_chimera_soc.sv
@@ -19,7 +19,7 @@ module fixture_chimera_soc #(
   import tb_cheshire_pkg::*;
   import chimera_pkg::*;
 
-  localparam chimera_cfg_t DutCfg = ChimeraCfg[SelectedCfg];
+  localparam chimera_cfg_t DutCfg = ChimeraCfg[1];
   localparam cheshire_cfg_t ChsCfg = DutCfg.ChsCfg;
 
   `CHESHIRE_TYPEDEF_ALL(, ChsCfg)
@@ -61,7 +61,7 @@ module fixture_chimera_soc #(
   logic [          3:0] spih_sd_en;
 
   chimera_top_wrapper #(
-    .SelectedCfg(SelectedCfg)
+    .Cfg(DutCfg)
   ) dut (
     .soc_clk_i                (soc_clk),
     .clu_clk_i                (clu_clk),


### PR DESCRIPTION
# Chimera Configuration Package
This PR reorganises the Chimera pkg which was becoming intricated, before integrating hyperbus config.
Additionally, the `IsolateClusters` parameter is now included in the Chimera cfg to have the possibility to overwrite its value from outside.