### PR TITLE
Reintroduced SelectCfg parameter

### DIFF
--- a/hw/chimera_pkg.sv
+++ b/hw/chimera_pkg.sv
@@ -186,18 +186,22 @@ ExtClusters
     return chimera_cfg;
   endfunction : gen_chimera_cfg
 
-  function automatic chimera_cfg_t gen_chimera_cfg_UPF;
+  function automatic chimera_cfg_t gen_chimera_cfg_isolate();
     chimera_cfg_t chimera_cfg;
     chimera_cfg                 = gen_chimera_cfg();
     // Override the isolation params
     chimera_cfg.IsolateClusters = 1;
 
     return chimera_cfg;
-  endfunction : gen_chimera_cfg_UPF
+  endfunction : gen_chimera_cfg_isolate
 
-  localparam int NumCfgs = 2;
+  localparam int unsigned NumCfgs = 2;
 
-  localparam chimera_cfg_t [NumCfgs-1:0] ChimeraCfg = {gen_chimera_cfg(), gen_chimera_cfg_UPF};
+  localparam chimera_cfg_t [NumCfgs-1:0] ChimeraCfg = {
+    gen_chimera_cfg_isolate(),  // 1: Configuration with Isolation for Power Managemenet
+    gen_chimera_cfg()  // 0: Default configuration
+  };
+
 
   localparam int unsigned RegDataWidth = 32;
   localparam type addr_t = logic [ChimeraCfg[0].ChsCfg.AddrWidth-1:0];

--- a/hw/chimera_top_wrapper.sv
+++ b/hw/chimera_top_wrapper.sv
@@ -9,7 +9,7 @@ module chimera_top_wrapper
   import chimera_pkg::*;
   import chimera_reg_pkg::*;
 #(
-  parameter chimera_cfg_t Cfg = '0
+  parameter int unsigned SelectedCfg = 0
 ) (
   input  logic                        soc_clk_i,
   input  logic                        clu_clk_i,
@@ -70,6 +70,7 @@ module chimera_top_wrapper
   `include "chimera/typedef.svh"
 
   // Cheshire config
+  localparam chimera_cfg_t Cfg = ChimeraCfg[SelectedCfg];
   localparam cheshire_cfg_t ChsCfg = Cfg.ChsCfg;
 
   `CHESHIRE_TYPEDEF_ALL(, ChsCfg)

--- a/target/sim/src/fixture_chimera_soc.sv
+++ b/target/sim/src/fixture_chimera_soc.sv
@@ -19,7 +19,7 @@ module fixture_chimera_soc #(
   import tb_cheshire_pkg::*;
   import chimera_pkg::*;
 
-  localparam chimera_cfg_t DutCfg = ChimeraCfg[1];
+  localparam chimera_cfg_t DutCfg = ChimeraCfg[SelectedCfg];
   localparam cheshire_cfg_t ChsCfg = DutCfg.ChsCfg;
 
   `CHESHIRE_TYPEDEF_ALL(, ChsCfg)
@@ -61,7 +61,7 @@ module fixture_chimera_soc #(
   logic [          3:0] spih_sd_en;
 
   chimera_top_wrapper #(
-    .Cfg(DutCfg)
+    .SelectedCfg(SelectedCfg)
   ) dut (
     .soc_clk_i                (soc_clk),
     .clu_clk_i                (clu_clk),

--- a/target/sim/vsim/start.chimera_soc.tcl
+++ b/target/sim/vsim/start.chimera_soc.tcl
@@ -16,7 +16,7 @@ if {![info exists VOPTARGS]} {
 }
 
 set flags "-permissive -suppress 3009 -suppress 8386 -error 7 "
-if {[info exists SELCFG]} { append flags "-GSelectedCfg=${SELCFG} " }
+if {[info exists SELCFG]} { append flags "-gSelectedCfg=${SELCFG} " }
 
 set pargs ""
 if {[info exists BOOTMODE]} { append pargs "+BOOTMODE=${BOOTMODE} " }


### PR DESCRIPTION
# SelectCfg Paramter
This PR reintroduces the `SelectCfg` parameter to allow selection of the Chimera Configuration structure.
Additionally, the `start.chimera_soc.tcl` file has been modified to prevent `-GSelectCfg` from overwriting parameters with the same name in different modules.