### PR TITLE
Bump Cheshire dependencies to revert AXI version

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -15,8 +15,8 @@ packages:
     - apb
     - register_interface
   axi:
-    revision: 587355b77b8ce94dcd600efbd5d5bd118ff913a7
-    version: 0.39.4
+    revision: 853ede23b2a9837951b74dbdc6d18c3eef5bac7d
+    version: 0.39.5
     source:
       Git: https://github.com/pulp-platform/axi.git
     dependencies:
@@ -44,8 +44,8 @@ packages:
     - common_cells
     - common_verification
   axi_rt:
-    revision: d5f857e74d0a5db4e4a2cc3652ca4f40f29a1484
-    version: 0.0.0-alpha.8
+    revision: 641ea950e24722af747033f2ab85f0e48ea8d7f8
+    version: 0.0.0-alpha.9
     source:
       Git: https://github.com/pulp-platform/axi_rt.git
     dependencies:
@@ -69,7 +69,7 @@ packages:
     - common_cells
     - register_interface
   cheshire:
-    revision: f9b9a1066143b8319c427bd790ab4729321b9f20
+    revision: 586cb0225be5c57f5ffcf67bd490763efd9b4d24
     version: null
     source:
       Git: https://github.com/pulp-platform/cheshire.git

--- a/Bender.yml
+++ b/Bender.yml
@@ -11,7 +11,7 @@ package:
 dependencies:
   register_interface:       { git: "https://github.com/pulp-platform/register_interface.git", version: 0.4.3  }
   axi:                      { git: "https://github.com/pulp-platform/axi.git",                version: 0.39.2 }
-  cheshire:                 { git: "https://github.com/pulp-platform/cheshire.git",           rev: f9b9a1066143b8319c427bd790ab4729321b9f20}
+  cheshire:                 { git: "https://github.com/pulp-platform/cheshire.git",           rev: 586cb0225be5c57f5ffcf67bd490763efd9b4d24}
   snitch_cluster:           { git: "https://github.com/pulp-platform/snitch_cluster.git",     rev: c12ce9b2af1ac8edf3d4feb18939e1ad20c42225}
   common_cells:             { git: "https://github.com/pulp-platform/common_cells.git",       version: 1.31.1}
   idma:                     { git: "https://github.com/pulp-platform/iDMA.git",               rev: 9edf489f57389dce5e71252c79e337f527d3aded}


### PR DESCRIPTION
# AXI Yanked version
This PR revert the AXI version to `0.39.3` due to yanking of `0.39.4`.
Both Cheshire and the Memory Island pointed to the yanked version.

**Note:** This PR will be merged once the Pull Request on the [Memory Island](https://github.com/pulp-platform/memory_island/pull/13) repo will be accepted.