### PR TITLE
Lleone/fix datawidthmismatch

### DIFF
--- a/hw/chimera_cluster_adapter.sv
+++ b/hw/chimera_cluster_adapter.sv
@@ -257,7 +257,7 @@ module chimera_cluster_adapter #(
     .AxiMstPortMaxTxnsPerId(16),                              // TODO: Tune this
 
     .AxiAddrWidth(AddrWidth),
-    .AxiDataWidth(WideDataWidth),
+    .AxiDataWidth(NarrowDataWidth),
     .AxiUserWidth(UserWidth),
 
     .slv_req_t (narrow_in_req_t),


### PR DESCRIPTION
# Data Width Mismatch
This PR fixes an issue with a wrong data width definition in the AXI adapter.
This error couldn't be identified previously because the `id_serializer` inside the `iw_converter` didn't make use of the dataWidth parameter. With the introduction of the newest AXI v0.39.5, this parameter has been introduced again and thus the error was triggered.