### PR TITLE
[TB]: Extend testbench to improve debugging

### DIFF
--- a/target/sim/src/vip_chimera_soc.sv
+++ b/target/sim/src/vip_chimera_soc.sv
@@ -329,7 +329,7 @@ module vip_chimera_soc
 
   // Wait for termination signal and get return code
   task automatic jtag_wait_for_eoc(output word_bt exit_code);
-    jtag_poll_bit0(AmRegs + cheshire_reg_pkg::CHESHIRE_SCRATCH_2_OFFSET, exit_code, 800);
+    jtag_poll_bit0(AmRegs + cheshire_reg_pkg::CHESHIRE_SCRATCH_2_OFFSET, exit_code, 4000);
     exit_code >>= 1;
     if (exit_code) $error("[JTAG] FAILED: return code %0d", exit_code);
     else $display("[JTAG] SUCCESS");
@@ -426,6 +426,7 @@ module vip_chimera_soc
         uart_boot_eoc = 1;
       end else begin
         uart_read_buf.push_back(bite);
+        $display("Read Byte: %s", bite);
       end
     end
   end


### PR DESCRIPTION
# Extend Testbench for better observability
This PR introduces some few adjustment to the Testbench to improve the observability when printing a word with UART.
Additionally, it also modify some parameters due to some issues encountered when testing the Chimrea PD design.
the goal of this PR, is to end up with a shared version of the VIP module.

## JTAG SBUSY Problem
The reason why the `idle_cycles`  have been increased to 4000, is to work around an issue with the task [jtag_poll_bit0](https://github.com/pulp-platform/chimera/blob/314e9477c051b01471efe2f2ff7741303caea4e4/target/sim/src/vip_chimera_soc.sv#L213C18-L213C32). This task uses the Debug Module function [read_dmi_exp_backoff](https://github.com/pulp-platform/riscv-dbg/blob/618ee6e0e2610ef47e0dcc4df6748af3dffff731/tb/jtag_dmi/jtag_test.sv#L229), which should not be used for read operations with side effects, as reading SBData0 is one such operation. 
For instance, if the clock signal is removed, something that can occur during FLL testing, the Debug Module may not complete the write operation before attempting to read SBData0. This results in the Debug Module appearing busy. Consequently, during the next iteration of the exponential backoff, the DMI resets without clearing the `sbusy` bit, which leaves the system in a perpetually unstable state.
This problem should be documented and addressed properly in a dedicated issue.