### PR TITLE
[MK]: Add make targets to build/clean the entire chimera SoC

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,21 @@ are not empty.
 
 
 To install the required python packages into your environment and setup dependencies, you can run
-```
+``` shell
 pip install -r requirements.txt
 
 bender checkout
 
+```
+If you have all needed dependencies and you want to build the entire Chimera SoC, both RTL and SW, just run
+
+``` shell
+make chim-all
+```
+If you want to build the system step by step, all the necessary make targets are listed below:
+
+To build Cheshire and Snitch run
+``` shell
 make chs-hw-init
 make snitch-hw-init
 ```

--- a/chimera.mk
+++ b/chimera.mk
@@ -10,6 +10,7 @@ CLINTCORES = 46
 PLICCORES = 92
 PLIC_NUM_INTRS = 92
 
+
 .PHONY: update_plic
 update_plic: $(CHS_ROOT)/hw/rv_plic.cfg.hjson
 	sed -i 's/src: .*/src: $(PLIC_NUM_INTRS),/' $<
@@ -78,10 +79,22 @@ chim-nonfree-init:
 -include $(CHIM_ROOT)/bender.mk
 
 # Necessary to build libchimera.a for bootrom.elf
-# TODO: Here the make chim-sw cannot work properly FIND SOLUTION !!!!!
 -include $(CHIM_ROOT)/sw/sw.mk
 
 # Include subdir Makefiles
 -include $(CHIM_ROOT)/utils/utils.mk
 # Include target makefiles
 -include $(CHIM_ROOT)/target/sim/sim.mk
+
+#################################
+# Phonies for the entire system #
+#################################
+
+CHIM_ALL += chs-hw-init snitch-hw-init chim-sw chim-bootrom-init chs-sim-all chim-sim
+CHIM_CLEAN += chim-sw-clean chim-sim-clean
+
+.PHONY: chim-all
+chim-all: $(CHIM_ALL)
+
+.PHONY: chim-clean
+chim-clean: $(CHIM_CLEAN)

--- a/target/sim/sim.mk
+++ b/target/sim/sim.mk
@@ -25,6 +25,8 @@ $(CHIM_SIM_DIR)/models/s27ks0641/s27ks0641.sv:
 HYP_USER_PRELOAD      ?= 0
 HYP0_PRELOAD_MEM_FILE ?= ""
 
+
+CHIM_VLOG_ARGS += -suppress 2583 -suppress 13314
 CHIM_VLOG_ARGS += +define+HYP_USER_PRELOAD="$(HYP_USER_PRELOAD)"
 CHIM_VLOG_ARGS += +define+HYP0_PRELOAD_MEM_FILE=\"$(HYP0_PRELOAD_MEM_FILE)\"
 # this path should be kept relative to the vsim directory to avoid CI issues:


### PR DESCRIPTION
# Simplify Make flow
This PR should solve issue #9. 
It introduces two make targets to build and clean the entire Chimera SoC simplifying the make flow. 
By running `make chim-all` the SW and RTL are built while `make chim-clean` can be used to delete both the binaries and the RTL compilation script. 
In this way, the building flow shoudl be the follwoing:
- `bender checkout`
- `make chim-all`

Additionally, some simulation flags that were mistakenly removed in #43 have been reintroduced.