### PR TITLE
[Verification] UART Debugging and Writeback

### DIFF
--- a/target/sim/src/vip_chimera_soc.sv
+++ b/target/sim/src/vip_chimera_soc.sv
@@ -439,9 +439,9 @@ module vip_chimera_soc
   // Continually read characters and print lines
   // TODO: we should be able to support CR properly, but buffers are hard to deal with...
   initial begin
-    static byte_bt        uart_read_buf[$];
-    static byte_bt        uart_fifo[$];
-    byte_bt               bite;
+    static byte_bt uart_read_buf[$];
+    static byte_bt uart_fifo    [$];
+    byte_bt        bite;
 
     // Two-byte command table
     typedef struct {
@@ -449,9 +449,7 @@ module vip_chimera_soc
       string  response;
     } uart_cmd_t;
 
-    static uart_cmd_t cmd_list[$] = '{
-      '{ pattern:{"W","B"}, response:"WB OK" }
-    };
+    static uart_cmd_t cmd_list[$] = '{'{pattern: {"W", "B"}, response: "WB OK"}};
 
     wait_for_reset();
     forever begin

--- a/target/sim/src/vip_chimera_soc.sv
+++ b/target/sim/src/vip_chimera_soc.sv
@@ -375,6 +375,7 @@ module vip_chimera_soc
   localparam byte_bt UartDebugAck = 'h06;
   localparam byte_bt UartDebugEot = 'h04;
   localparam byte_bt UartDebugEoc = 'h14;
+  localparam byte_bt UartWriteBack[5:0] = "UartWB";
 
   byte_bt uart_boot_byte;
   logic   uart_boot_ena;
@@ -440,7 +441,9 @@ module vip_chimera_soc
   // TODO: we should be able to support CR properly, but buffers are hard to deal with...
   initial begin
     static byte_bt uart_read_buf[$];
+    static byte_bt uart_fifo[$];
     byte_bt        bite;
+    static string uart_writeback_msg = "WB OK";
     wait_for_reset();
     forever begin
       uart_read_byte(bite);
@@ -455,6 +458,14 @@ module vip_chimera_soc
       end else begin
         uart_read_buf.push_back(bite);
         $display("Read Byte: %s", bite);
+        // VIVIANEP: Store all bytes in a FIFO to be read by the testbench
+        uart_fifo.push_back(bite);
+        if (uart_fifo == UartWriteBack) begin
+          for (int i = 0; i < uart_writeback_msg.len(); i++) begin
+            uart_write_byte(uart_writeback_msg[i]);
+          end
+          $display("[UART] %s", {>>8{uart_writeback_msg}});
+        end
       end
     end
   end

--- a/target/sim/src/vip_chimera_soc.sv
+++ b/target/sim/src/vip_chimera_soc.sv
@@ -375,7 +375,6 @@ module vip_chimera_soc
   localparam byte_bt UartDebugAck = 'h06;
   localparam byte_bt UartDebugEot = 'h04;
   localparam byte_bt UartDebugEoc = 'h14;
-  localparam byte_bt UartWriteBack[5:0] = "UartWB";
 
   byte_bt uart_boot_byte;
   logic   uart_boot_ena;


### PR DESCRIPTION
## Description
This PR adds UART debugging capabilities in the `vip_chimera_soc.sv` module by introducing a writeback mechanism and a FIFO for writeback handling in the testbench.

## Changes
- **Added a new UART writeback mechanism**:
  - Introduced a `UartWriteBack[5:0]` local parameter with the value `"UartWB"`.
  - Implemented a comparison against `UartWriteBack` in the UART handling logic.
  - When a match is detected, a predefined writeback message (`"WB OK"`) is sent via UART.
- **Added a FIFO buffer for UART writeback**:
  - Introduced a static FIFO (`uart_fifo`) to store all received bytes.
  - Enables the testbench to track UART transactions and trigger the writeback message.

## Motivation
- This change was made to **test the functionality of the UART peripheral** in Chimera after implementing its **driver and HAL** in the [chimera-sdk](https://github.com/pulp-platform/chimera-sdk). This is related to [PR #11](https://github.com/pulp-platform/chimera-sdk/pull/11), which is currently pending review.
- The writeback mechanism allows us to verify that the UART driver properly handles received data and responds as expected.
- The FIFO ensures that incoming UART data is stored and processed correctly for triggering writebacks.

## Testing
- Simulated the `vip_chimera_soc` module to verify correct handling of the UART FIFO and writeback message using the tests in the [chimera-sdk](https://github.com/pulp-platform/chimera-sdk).
- Confirmed that expected messages are displayed when `"UartWB"` is received.