### PR TITLE
[sw] Add clock gating helper functions and disable clock gating by default

### DIFF
--- a/sw/include/offload.h
+++ b/sw/include/offload.h
@@ -3,13 +3,17 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 // Moritz Scherer <scheremo@iis.ee.ethz.ch>
+// Viviane Potocnik <vivianep@iis.ee.ethz.ch>
 
 #ifndef _OFFLOAD_INCLUDE_GUARD_
 #define _OFFLOAD_INCLUDE_GUARD_
 
+#include <stdbool.h>
 #include <stdint.h>
 
 void setupInterruptHandler(void *handler);
+void setClusterClockGating(uint8_t *regPtr, uint8_t clusterId, bool enable);
+void setAllClusterClockGating(uint8_t *regPtr, bool enable);
 void offloadToCluster(void *function, uint8_t hartId);
 void waitClusterBusy(uint8_t clusterId);
 uint32_t waitForCluster(uint8_t clusterId);

--- a/sw/lib/offload.c
+++ b/sw/lib/offload.c
@@ -3,10 +3,13 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 // Moritz Scherer <scheremo@iis.ee.ethz.ch>
+// Viviane Potocnik <vivianep@iis.ee.ethz.ch>
 
 #include "regs/soc_ctrl.h"
 #include "soc_addr_map.h"
+#include <stdbool.h>
 #include <stdint.h>
+#include <stdio.h>
 
 void setupInterruptHandler(void *handler) {
     volatile void **snitchTrapHandlerAddr =
@@ -39,6 +42,36 @@ void waitClusterBusy(uint8_t clusterId) {
     }
 
     return;
+}
+
+/* Set Clock Gating on specified cluster */
+void setClusterClockGating(volatile uint8_t *regPtr, uint8_t clusterId, bool enable) {
+
+    if (regPtr == NULL) return;
+
+    if (clusterId == 0) {
+        *(regPtr + CHIMERA_CLUSTER_0_CLK_GATE_EN_REG_OFFSET) = enable;
+    } else if (clusterId == 1) {
+        *(regPtr + CHIMERA_CLUSTER_1_CLK_GATE_EN_REG_OFFSET) = enable;
+    } else if (clusterId == 2) {
+        *(regPtr + CHIMERA_CLUSTER_2_CLK_GATE_EN_REG_OFFSET) = enable;
+    } else if (clusterId == 3) {
+        *(regPtr + CHIMERA_CLUSTER_3_CLK_GATE_EN_REG_OFFSET) = enable;
+    } else if (clusterId == 4) {
+        *(regPtr + CHIMERA_CLUSTER_4_CLK_GATE_EN_REG_OFFSET) = enable;
+    }
+}
+
+/* Set Clock Gating on all clusters */
+void setAllClusterClockGating(volatile uint8_t *regPtr, bool enable) {
+
+    if (regPtr == NULL) return;
+
+    *(regPtr + CHIMERA_CLUSTER_0_CLK_GATE_EN_REG_OFFSET) = enable;
+    *(regPtr + CHIMERA_CLUSTER_1_CLK_GATE_EN_REG_OFFSET) = enable;
+    *(regPtr + CHIMERA_CLUSTER_2_CLK_GATE_EN_REG_OFFSET) = enable;
+    *(regPtr + CHIMERA_CLUSTER_3_CLK_GATE_EN_REG_OFFSET) = enable;
+    *(regPtr + CHIMERA_CLUSTER_4_CLK_GATE_EN_REG_OFFSET) = enable;
 }
 
 /* Offloads a void function pointer to the specified cluster's core 0 */

--- a/sw/tests/testCluster.c
+++ b/sw/tests/testCluster.c
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 // Moritz Scherer <scheremo@iis.ee.ethz.ch>
+// Viviane Potocnik <vivianep@iis.ee.ethz.ch>
 
 #include <soc_addr_map.h>
 #include <stdint.h>
@@ -14,6 +15,9 @@
 #define TESTVAL 0x00E0D0C0
 
 int main() {
+    volatile uint8_t *clockGatingRegPtr = (volatile uint8_t *)SOC_CTRL_BASE;
+    setAllClusterClockGating(clockGatingRegPtr, 1);
+
     volatile int32_t *clusterMemPtr = (volatile int32_t *)CLUSTERMEMORYSTART;
     volatile int32_t result;
 

--- a/sw/tests/testCluster.c
+++ b/sw/tests/testCluster.c
@@ -16,7 +16,7 @@
 
 int main() {
     volatile uint8_t *clockGatingRegPtr = (volatile uint8_t *)SOC_CTRL_BASE;
-    setAllClusterClockGating(clockGatingRegPtr, 1);
+    setAllClusterClockGating(clockGatingRegPtr, 0);
 
     volatile int32_t *clusterMemPtr = (volatile int32_t *)CLUSTERMEMORYSTART;
     volatile int32_t result;

--- a/sw/tests/testClusterOffload.c
+++ b/sw/tests/testClusterOffload.c
@@ -33,7 +33,7 @@ int32_t testReturn() {
 
 int main() {
     volatile uint8_t *clockGatingRegPtr = (volatile uint8_t *)SOC_CTRL_BASE;
-    setAllClusterClockGating(clockGatingRegPtr, 1);
+    setAllClusterClockGating(clockGatingRegPtr, 0);
     setupInterruptHandler(clusterTrapHandler);
     offloadToCluster(testReturn, 0);
     uint32_t retVal = waitForCluster(0);

--- a/sw/tests/testClusterOffload.c
+++ b/sw/tests/testClusterOffload.c
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 // Moritz Scherer <scheremo@iis.ee.ethz.ch>
+// Viviane Potocnik <vivianep@iis.ee.ethz.ch>
 
 // Simple offload test. Set the trap handler first, offload a function, retrieve
 // return value from cluster. Does not currently take care of stack
@@ -31,6 +32,8 @@ int32_t testReturn() {
 }
 
 int main() {
+    volatile uint8_t *clockGatingRegPtr = (volatile uint8_t *)SOC_CTRL_BASE;
+    setAllClusterClockGating(clockGatingRegPtr, 1);
     setupInterruptHandler(clusterTrapHandler);
     offloadToCluster(testReturn, 0);
     uint32_t retVal = waitForCluster(0);

--- a/sw/tests/testHyperbusAddr.c
+++ b/sw/tests/testHyperbusAddr.c
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 // Sergio Mazzola <smazzola@iis.ee.ethz.ch>
+// Viviane Potocnik <vivianep@iis.ee.ethz.ch>
 
 // Test HyperRAM addressability through the Hyperbus peripheral
 
@@ -13,6 +14,8 @@
 #define TESTVAL (uint32_t)0x1234ABCD
 
 int main() {
+    volatile uint8_t *clockGatingRegPtr = (volatile uint8_t *)SOC_CTRL_BASE;
+    setAllClusterClockGating(clockGatingRegPtr, 1);
     volatile uint32_t *hyperMemPtr = (volatile uint32_t *)HYPER_BASE;
     volatile uint32_t result;
 

--- a/sw/tests/testHyperbusAddr.c
+++ b/sw/tests/testHyperbusAddr.c
@@ -15,7 +15,7 @@
 
 int main() {
     volatile uint8_t *clockGatingRegPtr = (volatile uint8_t *)SOC_CTRL_BASE;
-    setAllClusterClockGating(clockGatingRegPtr, 1);
+    setAllClusterClockGating(clockGatingRegPtr, 0);
     volatile uint32_t *hyperMemPtr = (volatile uint32_t *)HYPER_BASE;
     volatile uint32_t result;
 

--- a/sw/tests/testMemBypass.c
+++ b/sw/tests/testMemBypass.c
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 // Lorenzo Leone <lleone@iis.ee.ethz.ch>
+// Viviane Potocnik <vivianep@iis.ee.ethz.ch>
 
 // Test to check if clusters can access the memory island both using
 // the wide interconnect and the narrow AXI.
@@ -58,6 +59,9 @@ int32_t __attribute__((aligned(32))) testMemWide() {
 }
 
 int main() {
+    volatile uint8_t *clockGatingRegPtr = (volatile uint8_t *)SOC_CTRL_BASE;
+    setAllClusterClockGating(clockGatingRegPtr, 1);
+
     volatile int32_t *regPtr = 0;
 
     uint32_t retVal = 0;

--- a/sw/tests/testMemBypass.c
+++ b/sw/tests/testMemBypass.c
@@ -60,7 +60,7 @@ int32_t __attribute__((aligned(32))) testMemWide() {
 
 int main() {
     volatile uint8_t *clockGatingRegPtr = (volatile uint8_t *)SOC_CTRL_BASE;
-    setAllClusterClockGating(clockGatingRegPtr, 1);
+    setAllClusterClockGating(clockGatingRegPtr, 0);
 
     volatile int32_t *regPtr = 0;
 

--- a/sw/tests/testPeripheralsGating.c
+++ b/sw/tests/testPeripheralsGating.c
@@ -19,7 +19,7 @@
 
 int main() {
     volatile uint8_t *clockGatingRegPtr = (volatile uint8_t *)SOC_CTRL_BASE;
-    setAllClusterClockGating(clockGatingRegPtr, 1);
+    setAllClusterClockGating(clockGatingRegPtr, 0);
 
     volatile uint32_t *regPtr = 0;
     uint8_t expVal;

--- a/sw/tests/testPeripheralsGating.c
+++ b/sw/tests/testPeripheralsGating.c
@@ -3,18 +3,24 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 // Lorenzo Leone <lleone@iis.ee.ethz.ch>
-//
+// Viviane Potocnik <vivianep@iis.ee.ethz.ch>
+
 // This test aims to check if the clock gating registers
 // inside Cheshire can be correctly driven from Chimera.
 // The test is not automated; each peripheral's clock
 // signal must be manually checked by looking at the waveforms.
 
 #include <stdint.h>
+#include "offload.h"
 #include "regs/cheshire.h"
+#include "soc_addr_map.h"
 
 #define CHESHIRE_REGS_BASE 0x03000000
 
 int main() {
+    volatile uint8_t *clockGatingRegPtr = (volatile uint8_t *)SOC_CTRL_BASE;
+    setAllClusterClockGating(clockGatingRegPtr, 1);
+
     volatile uint32_t *regPtr = 0;
     uint8_t expVal;
 

--- a/sw/tests/testReturnZero.c
+++ b/sw/tests/testReturnZero.c
@@ -2,23 +2,14 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 //
-// Moritz Scherer <scheremo@iis.ee.ethz.ch>
 // Viviane Potocnik <vivianep@iis.ee.ethz.ch>
 
-#include "regs/soc_ctrl.h"
-#include "soc_addr_map.h"
-#include "offload.h"
+#include <soc_addr_map.h>
 #include <stdint.h>
 
 int main() {
     volatile uint8_t *clockGatingRegPtr = (volatile uint8_t *)SOC_CTRL_BASE;
-
-    setClusterClockGating(clockGatingRegPtr, 0, 1);
-    setClusterClockGating(clockGatingRegPtr, 3, 1);
-    setClusterClockGating(clockGatingRegPtr, 4, 1);
-
-    while (1) {
-    }
+    setAllClusterClockGating(clockGatingRegPtr, 1);
 
     return 0;
 }

--- a/sw/tests/testReturnZero.c
+++ b/sw/tests/testReturnZero.c
@@ -9,7 +9,7 @@
 
 int main() {
     volatile uint8_t *clockGatingRegPtr = (volatile uint8_t *)SOC_CTRL_BASE;
-    setAllClusterClockGating(clockGatingRegPtr, 1);
+    setAllClusterClockGating(clockGatingRegPtr, 0);
 
     return 0;
 }


### PR DESCRIPTION
## Description
This PR introduces **cluster clock gating control functions** to manage enabling and disabling clock gating for individual and all clusters. These functions are now integrated across tests to ensure proper initialization.

##  Changes
- **Added clock gating control functions:**
  - `setClusterClockGating(volatile uint8_t *regPtr, uint8_t clusterId, bool enable)`: Sets the clock gating register of cluster `clusterId` to `enable`
  - `setAllClusterClockGating(volatile uint8_t *regPtr, bool enable)`: Sets clock gating registers of all clusters to `enable`
- **Integrated default clock gating behavior in tests**:
  - **Clock gating is now disabled by default** in all tests except for the dedicated clock gating tests.
