### PR TITLE
[RTL]: Increase Memory Island bank depth

### DIFF
--- a/hw/chimera_pkg.sv
+++ b/hw/chimera_pkg.sv
@@ -128,7 +128,7 @@ ExtClusters
   localparam byte_bt MemIslNarrowPorts = 1;
   localparam byte_bt MemIslWidePorts = $countones(ChimeraClusterCfg.hasWideMasterPort);
   localparam byte_bt MemIslNumWideBanks = 2;
-  localparam shrt_bt MemIslWordsPerBank = 1024;
+  localparam shrt_bt MemIslWordsPerBank = 2048;
 
   // Hyperbus
   localparam byte_bt HyperbusIdx = MemIslandIdx + 1;

--- a/target/sim/vsim/start.chimera_soc.tcl
+++ b/target/sim/vsim/start.chimera_soc.tcl
@@ -25,7 +25,7 @@ if {[info exists BINARY]}   { append pargs "+BINARY=${BINARY} " }
 if {[info exists IMAGE]}    { append pargs "+IMAGE=${IMAGE} " }
 
 if {[catch {
-    eval "vsim -c ${TESTBENCH} -t 1ps -vopt -voptargs=\"${VOPTARGS}\"" ${pargs} ${flags}
+    eval "vsim -c ${TESTBENCH} -t 1ps -vopt -voptargs=\"${VOPTARGS}\"" ${pargs} ${flags} "-do \"log -r /*;\""
 }]} {return 1}
 
 set StdArithNoWarnings 1


### PR DESCRIPTION
# Increase Memory Island size
This PR increases the bank size of the memory island from 1024 to 2048 words. Now the SoC has a 256 kiB memory island made of 32 narrow banks. 