### PR TITLE
Small QoL (quality-of-life) improvements

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -27,7 +27,6 @@ workspace:
   package_links:
     cheshire: cheshire
     idma: idma
-    hyperbus: hyperbus
 
 sources:
   - hw/chimera_pkg.sv

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,6 @@ CHIM_ROOT ?= $(shell pwd)
 
 # Tooling
 BENDER                 ?= bender -d $(CHIM_ROOT)
-PADRICK                ?= padrick
 VERIBLE_VERILOG_FORMAT ?= $(CHIM_UTILS_DIR)/verible-verilog/verible-verilog-format
 
 CHS_ROOT    ?= $(shell $(BENDER) path cheshire)

--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,20 @@ CHIM_ROOT ?= $(shell pwd)
 BENDER                 ?= bender -d $(CHIM_ROOT)
 VERIBLE_VERILOG_FORMAT ?= $(CHIM_UTILS_DIR)/verible-verilog/verible-verilog-format
 
+# Set dependency paths only if dependencies have already been cloned
+# This avoids running `bender checkout` at every make command
+ifeq ($(shell test -d $(CHIM_ROOT)/.bender || echo 1),)
 CHS_ROOT    ?= $(shell $(BENDER) path cheshire)
 SNITCH_ROOT ?= $(shell $(BENDER) path snitch_cluster)
 IDMA_ROOT   ?= $(shell $(BENDER) path idma)
 HYPERB_ROOT ?= $(shell $(BENDER) path hyperbus)
+endif
+
+# Fall back to safe defaults if dependencies are not cloned yet
+CHS_ROOT    ?= .
+SNITCH_ROOT ?= .
+IDMA_ROOT   ?= .
+HYPERB_ROOT ?= .
 
 CHS_XLEN ?= 32
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,3 @@ mako
 jsonref
 jsonschema
 flatdict
-padrick @ git+https://github.com/pulp-platform/padrick@v0.3.6

--- a/utils/utils.mk
+++ b/utils/utils.mk
@@ -17,7 +17,7 @@ FORMAT_VERILOG_SRC = $(wildcard \
 )
 
 # Checks if verible-verilog-format is installed, otherwise it looks for a Makefile target in our flow to install it
-format-verilog: $(shell if ! `which $(VERIBLE_VERILOG_FORMAT)`; then echo $(VERIBLE_VERILOG_FORMAT); fi)
+format-verilog: $(shell if ! `which $(VERIBLE_VERILOG_FORMAT) 2> /dev/null`; then echo $(VERIBLE_VERILOG_FORMAT); fi)
 	$(VERIBLE_VERILOG_FORMAT) --flagfile .verilog_format --inplace --verbose $(FORMAT_VERILOG_SRC)
 
 # Download verible-verilog-format


### PR DESCRIPTION
The global makefile variables defined in a way like
```
CHS_ROOT    ?= $(shell $(BENDER) path cheshire)
SNITCH_ROOT ?= $(shell $(BENDER) path snitch_cluster)
```
call `bender checkout` any time whichever make command is executed, clogging stdout with uninformative output and slowing down operation. Thanks @ezelioli @creinwar ❤️ 
This PR solves mainly this issue and applies other small fixes.