### PR TITLE
[HOT FIX]: Hard code hyperbus model source from internal machine

### DIFF
--- a/target/sim/sim.mk
+++ b/target/sim/sim.mk
@@ -18,9 +18,11 @@ chim-sim: chim-hyperram-model $(CHIM_SIM_DIR)/vsim/compile.tcl
 .PHONY: chim-hyperram-model
 chim-hyperram-model: $(CHIM_SIM_DIR)/models/s27ks0641/s27ks0641.sv
 $(CHIM_SIM_DIR)/models/s27ks0641/s27ks0641.sv:
-	make -C $(HYPERB_ROOT) models/s27ks0641
+	# make -C $(HYPERB_ROOT) models/s27ks0641
 	mkdir -p $(dir $@)
-	cp -r $(HYPERB_ROOT)/models/s27ks0641 $(CHIM_SIM_DIR)/models
+#TODO: This is an hotfix, change when https://github.com/pulp-platform/hyperbus/issues/22 is solved
+	cp -r /usr/scratch/simba/lleone/InvecasHyper/models/s27ks0641 $(CHIM_SIM_DIR)/models
+
 # Defines for hyperram model preload at time 0
 HYP_USER_PRELOAD      ?= 0
 HYP0_PRELOAD_MEM_FILE ?= ""


### PR DESCRIPTION
## Hyperbus Model
The HyperBus model can no longer be automatically downloaded from the Invecas page because the [link](https://www.infineon.com/dgdl/Infineon-S27KL0641_S27KS0641_VERILOG-SimulationModels-v05_00-EN.zip?fileId=8ac78c8c7d0d8da4017d0f6349a14f68) now leads to a login page, preventing the automatic retrieval of the zip file containing the model.
To address this, the manually downloaded model has been placed on one of the IIS machines (simba). The Make flow used to build the testbench will now fetch the model directly from that machine, which resolves the CI issue.
This fix allows us to continue development using the CI, but we need a better long-term solution so that the repository can remain open-source and still be used from others.

**This PR is necessary to have a working nonfree CI and to continue the development.**