### PR TITLE
Increase memory island to 128 KiB

### DIFF
--- a/hw/chimera_pkg.sv
+++ b/hw/chimera_pkg.sv
@@ -128,11 +128,12 @@ ExtClusters
   localparam doub_bt MemIslRegionEnd = 64'h4804_0000;
 
   localparam aw_bt MemIslAxiMstIdWidth = 1;
-  localparam byte_bt MemIslNarrowToWideFactor = 4;
+  localparam byte_bt MemIslNarrowToWideFactor = 16;
   localparam byte_bt MemIslNarrowPorts = 1;
   localparam byte_bt MemIslWidePorts = $countones(ChimeraClusterCfg.hasWideMasterPort);
   localparam byte_bt MemIslNumWideBanks = 2;
   localparam shrt_bt MemIslWordsPerBank = 1024;
+  // Memory Island size = 16 * 2 * 1024 * 4 B = 128 KB
 
   // Hyperbus
   localparam byte_bt HyperbusIdx = MemIslandIdx + 1;


### PR DESCRIPTION
# Summary

This pull request increases the **memory island’s narrow-to-wide factor** in the `ExtClusters` module to improve memory utilization and alignment with cluster configurations.

# Details

- **Updated Parameter:** `MemIslNarrowToWideFactor` increased from **4 → 16**.  
- This change increases the **memory island size to 128 KiB**.  
- The previous configuration (32 KiB) was insufficient, as most binaries could not fit within that size, whereas the cluster TCDM is already 128 KiB, making this adjustment more consistent and practical.
