### PR TITLE
Bump Snitch cluster to latest revision

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -17,10 +17,10 @@ packages:
     - obi_peripherals
     - register_interface
   axi:
-    revision: f07498d53ecd5518b277c7d213ec3b71ca4df93c
-    version: 0.39.7
+    revision: 8e04779f341eb2c89412aae92223a292beef487e
+    version: null
     source:
-      Git: https://github.com/pulp-platform/axi.git
+      Git: https://github.com/colluca/axi
     dependencies:
     - common_cells
     - common_verification
@@ -111,8 +111,8 @@ packages:
     - common_cells
     - register_interface
   cluster_icache:
-    revision: 0e1fb6751d9684d968ba7fb40836e6118b448ecd
-    version: 0.1.1
+    revision: 64e21ae455bbdde850c4df13bef86ea55ac42537
+    version: 0.2.0
     source:
       Git: https://github.com/pulp-platform/cluster_icache.git
     dependencies:
@@ -177,8 +177,8 @@ packages:
     - register_interface
     - tech_cells_generic
   idma:
-    revision: 9edf489f57389dce5e71252c79e337f527d3aded
-    version: null
+    revision: 28a36e5e07705549e59fc33db96ab681bc1ca88e
+    version: 0.6.5
     source:
       Git: https://github.com/pulp-platform/iDMA.git
     dependencies:
@@ -234,8 +234,8 @@ packages:
     - register_interface
     - tech_cells_generic
   register_interface:
-    revision: 5daa85d164cf6b54ad061ea1e4c6f3624556e467
-    version: 0.4.5
+    revision: 8e8c209ea559d3b54f45cf30fcce95ce70ff5e49
+    version: 0.4.6
     source:
       Git: https://github.com/pulp-platform/register_interface.git
     dependencies:
@@ -268,18 +268,18 @@ packages:
     - common_cells
     - register_interface
   snitch_cluster:
-    revision: c12ce9b2af1ac8edf3d4feb18939e1ad20c42225
+    revision: 5b2fccd96c42812774c20ab2f9b811e164809789
     version: null
     source:
       Git: https://github.com/pulp-platform/snitch_cluster.git
     dependencies:
+    - apb
     - axi
     - axi_riscv_atomics
     - cluster_icache
     - common_cells
     - fpnew
     - idma
-    - register_interface
     - riscv-dbg
     - tech_cells_generic
   tech_cells_generic:

--- a/Bender.yml
+++ b/Bender.yml
@@ -10,11 +10,11 @@ package:
 
 dependencies:
   register_interface:       { git: "https://github.com/pulp-platform/register_interface.git", version: 0.4.3  }
-  axi:                      { git: "https://github.com/pulp-platform/axi.git",                version: 0.39.2 }
+  axi:                      { git: https://github.com/colluca/axi,                            rev: multicast }
   cheshire:                 { git: "https://github.com/pulp-platform/cheshire.git",           rev: 586cb0225be5c57f5ffcf67bd490763efd9b4d24}
-  snitch_cluster:           { git: "https://github.com/pulp-platform/snitch_cluster.git",     rev: c12ce9b2af1ac8edf3d4feb18939e1ad20c42225}
+  snitch_cluster:           { git: "https://github.com/pulp-platform/snitch_cluster.git",     rev: 5b2fccd96c42812774c20ab2f9b811e164809789}
   common_cells:             { git: "https://github.com/pulp-platform/common_cells.git",       version: 1.31.1}
-  idma:                     { git: "https://github.com/pulp-platform/iDMA.git",               rev: 9edf489f57389dce5e71252c79e337f527d3aded}
+  idma:                     { git: "https://github.com/pulp-platform/iDMA.git",               version: 0.6.5 }
   memory_island:            { git: "https://github.com/pulp-platform/memory_island.git",      rev: 64828cb7a9ccc1f1656ec92d06129072f445c319 } # main branch
   apb:                      { git: "https://github.com/pulp-platform/apb.git",                version: 0.2.4          }
   hyperbus:                 { git: "https://github.com/pulp-platform/hyperbus.git",           rev: aottaviano/nonfree } # TMP: to fix hyperbus model issue

--- a/chimera.mk
+++ b/chimera.mk
@@ -6,9 +6,9 @@
 # Lorenzo Leone <lleone@iis.ee.ethz.ch>
 
 
-CLINTCORES = 46
-PLICCORES = 92
-PLIC_NUM_INTRS = 92
+CLINTCORES = 46     # 1 + tot. #cores (e.g. 5 clusters * 9 cores + 1 = 46)
+PLICCORES = 92      # 2 + 2 * tot. #cores (e.g. 2 * 5 clusters * 9 cores + 2 = 92)
+PLIC_NUM_INTRS = 59 # 58 + ChsCfg.NumExtInIntrs + 1
 
 
 .PHONY: update_plic
@@ -28,7 +28,7 @@ chs-hw-init: update_plic gen_idma_hw $(CHIM_SW_LIB) ## Generate Cheshire RTL
 
 .PHONY: snitch-hw-init
 snitch-hw-init: ## Generate Snitch RTL
-	make -C $(SNITCH_ROOT)/target/snitch_cluster bin/snitch_cluster.vsim
+	make -C $(SNITCH_ROOT) vsim
 
 .PHONY: $(CHIM_SW_DIR)/include/regs/soc_ctrl.h
 $(CHIM_SW_DIR)/include/regs/soc_ctrl.h: $(CHIM_ROOT)/hw/regs/chimera_regs.hjson

--- a/hw/chimera_pkg.sv
+++ b/hw/chimera_pkg.sv
@@ -127,6 +127,8 @@ ExtClusters
   localparam doub_bt MemIslRegionStart = 64'h4800_0000;
   localparam doub_bt MemIslRegionEnd = 64'h4804_0000;
 
+  // Size of memory island: MemIslNumWideBanks * MemIslNarrowToWideFactor * MemIslWordsPerBank * <BytesPerWord>
+  // with BytesPerWord = cfg.AxiDataWidth / 8
   localparam aw_bt MemIslAxiMstIdWidth = 1;
   localparam byte_bt MemIslNarrowToWideFactor = 4;
   localparam byte_bt MemIslNarrowPorts = 1;
@@ -145,6 +147,12 @@ ExtClusters
 
   localparam int unsigned LogDepth = 3;
   localparam int unsigned SyncStages = 3;
+
+  // ------------
+  // |   TCDM   |
+  // ------------
+  localparam doub_bt TcdmSize = 128;
+  localparam aw_bt TcdmAddrWidth = $clog2(TcdmSize * 1024);
 
   // -------------------
   // |   Generate Cfg   |
@@ -173,7 +181,7 @@ ExtClusters
     // AXI CFG
     cfg.AxiMstIdWidth = 2;
     cfg.AxiDataWidth = 32;
-    cfg.AddrWidth = 32;
+    cfg.AddrWidth = 48;
     cfg.LlcOutRegionEnd = 'hFFFF_FFFF;
 
     cfg.AxiExtNumWideMst = $countones(ChimeraClusterCfg.hasWideMasterPort);

--- a/hw/clusters/chimera_cluster.sv
+++ b/hw/clusters/chimera_cluster.sv
@@ -51,6 +51,7 @@ module chimera_cluster
 );
 
   `include "axi/typedef.svh"
+  `include "tcdm_interface/typedef.svh"
 
   localparam int WideDataWidth = $bits(wide_out_req_o.w.data);
 
@@ -219,6 +220,11 @@ module chimera_cluster
   localparam int unsigned NumIntOutstandingLoads[NrCores] = '{NrCores{32'h1}};
   localparam int unsigned NumIntOutstandingMem[NrCores] = '{NrCores{32'h4}};
 
+  typedef logic [WideDataWidth-1:0] data_dma_t;
+  typedef logic [WideDataWidth/8-1:0] strb_dma_t;
+  typedef logic [TcdmAddrWidth-1:0] tcdm_addr_t;
+  `TCDM_TYPEDEF_ALL(tcdm_dma, tcdm_addr_t, data_dma_t, strb_dma_t, logic)
+
   snitch_cluster #(
     .PhysicalAddrWidth(Cfg.ChsCfg.AddrWidth),
     .NarrowDataWidth  (ClusterDataWidth),            // SCHEREMO: Convolve needs this...
@@ -228,7 +234,8 @@ module chimera_cluster
     .NarrowUserWidth  (Cfg.ChsCfg.AxiUserWidth),
     .WideUserWidth    (Cfg.ChsCfg.AxiUserWidth),
 
-    .BootAddr(SnitchBootROMRegionStart),
+    .BootAddr        (SnitchBootROMRegionStart),
+    .IntBootromEnable(0),
 
     .NrHives          (1),
     .NrCores          (NrCores),
@@ -242,7 +249,7 @@ module chimera_cluster
 
     .ICacheLineWidth('{256}),
     .ICacheLineCount('{16}),
-    .ICacheSets     ('{2}),
+    .ICacheWays     ('{2}),
 
     .VMSupport(0),
     .Xdma     ({1'b1, {(NrCores - 1) {1'b0}}}),
@@ -263,6 +270,8 @@ module chimera_cluster
     .narrow_out_resp_t(axi_cluster_out_narrow_resp_t),
     .wide_out_req_t   (axi_cluster_out_wide_req_t),
     .wide_out_resp_t  (axi_cluster_out_wide_resp_t),
+    .tcdm_dma_req_t   (tcdm_dma_req_t),
+    .tcdm_dma_rsp_t   (tcdm_dma_rsp_t),
 
     .sram_cfg_t (sram_cfg_t),
     .sram_cfgs_t(sram_cfgs_t),
@@ -279,6 +288,7 @@ module chimera_cluster
     .meip_i     (meip_i),
     .mtip_i     (mtip_i),
     .msip_i     (msip_i),
+    .mxip_i     ('0),
 
     .hart_base_id_i     (hart_base_id_i),
     .cluster_base_addr_i(cluster_base_addr_i),
@@ -291,7 +301,12 @@ module chimera_cluster
     .wide_in_req_i    ('0),
     .wide_in_resp_o   (),
     .wide_out_req_o   (clu_axi_wide_mst_req),
-    .wide_out_resp_i  (clu_axi_wide_mst_resp)
+    .wide_out_resp_i  (clu_axi_wide_mst_resp),
+
+    .narrow_ext_req_o (),
+    .narrow_ext_resp_i('0),
+    .tcdm_ext_req_i   ('0),
+    .tcdm_ext_resp_o  ()
 
   );
 endmodule

--- a/iis-env.sh
+++ b/iis-env.sh
@@ -13,6 +13,7 @@ export RISCV_GCC_BINROOT=/usr/pack/riscv-1.0-kgf/pulp-gcc-2.5.0/bin
 export CC=/usr/pack/gcc-11.2.0-af/linux-x64/bin/gcc
 export CXX=/usr/pack/gcc-11.2.0-af/linux-x64/bin/g++
 export CMAKE=cmake-3.28.3
+export SN_LLVM_BINROOT=/usr/scratch2/vulcano/colluca/tools/riscv32-snitch-llvm-almalinux8-15.0.0-snitch-0.2.0/bin
 
 # Create the python venv
 if [ ! -d ".venv" ]; then

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ mako
 jsonref
 jsonschema
 flatdict
+json5
+peakrdl-rawheader@git+https://github.com/colluca/PeakRDL-rawheader.git@7b8dbc9ad5854dc1cdaf36d4ea024c29ffb00a4c

--- a/target/sim/src/fixture_chimera_soc.sv
+++ b/target/sim/src/fixture_chimera_soc.sv
@@ -130,6 +130,8 @@ module fixture_chimera_soc #(
     .hyper_dq_o               (hyper_dq_o),
     .hyper_dq_oe_o            (hyper_dq_oe_o),
     .hyper_reset_no           (hyper_reset_no),
+    .apb_req_o                (),
+    .apb_rsp_i                ('0),
     .pmu_rst_clusters_ni      ({ExtClusters{rst_n}}),
     .pmu_clkgate_en_clusters_i(),
     .pmu_iso_en_clusters_i    ('0),                    // Never Isolate


### PR DESCRIPTION
This PR updates the Snitch cluster to pulp-platform/snitch_cluster@5b2fccd.

### Main changes
- Updated Bender yaml and lock files to match upstream dependencies.
  - Notable change: switched `axi` to https://github.com/colluca/axi (branch `multicast`).
- Updated `chimera_pkg` to match the current Snitch cluster's defaults.
- Added TCDM-related configuration to match the updated Snitch cluster.
- Updated `chimera_cluster`, adding connections to new Snitch cluster's ports.

### Verification
- All tests under `sw/tests` pass in vsim.