### PR TITLE
Bump snitch

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -17,10 +17,10 @@ packages:
     - obi_peripherals
     - register_interface
   axi:
-    revision: f07498d53ecd5518b277c7d213ec3b71ca4df93c
-    version: 0.39.7
+    revision: 8e04779f341eb2c89412aae92223a292beef487e
+    version: null
     source:
-      Git: https://github.com/pulp-platform/axi.git
+      Git: https://github.com/colluca/axi
     dependencies:
     - common_cells
     - common_verification
@@ -111,8 +111,8 @@ packages:
     - common_cells
     - register_interface
   cluster_icache:
-    revision: 0e1fb6751d9684d968ba7fb40836e6118b448ecd
-    version: 0.1.1
+    revision: 64e21ae455bbdde850c4df13bef86ea55ac42537
+    version: 0.2.0
     source:
       Git: https://github.com/pulp-platform/cluster_icache.git
     dependencies:
@@ -177,8 +177,8 @@ packages:
     - register_interface
     - tech_cells_generic
   idma:
-    revision: 9edf489f57389dce5e71252c79e337f527d3aded
-    version: null
+    revision: 28a36e5e07705549e59fc33db96ab681bc1ca88e
+    version: 0.6.5
     source:
       Git: https://github.com/pulp-platform/iDMA.git
     dependencies:
@@ -234,8 +234,8 @@ packages:
     - register_interface
     - tech_cells_generic
   register_interface:
-    revision: 5daa85d164cf6b54ad061ea1e4c6f3624556e467
-    version: 0.4.5
+    revision: 8e8c209ea559d3b54f45cf30fcce95ce70ff5e49
+    version: 0.4.6
     source:
       Git: https://github.com/pulp-platform/register_interface.git
     dependencies:
@@ -268,18 +268,18 @@ packages:
     - common_cells
     - register_interface
   snitch_cluster:
-    revision: c12ce9b2af1ac8edf3d4feb18939e1ad20c42225
+    revision: 5b2fccd96c42812774c20ab2f9b811e164809789
     version: null
     source:
       Git: https://github.com/pulp-platform/snitch_cluster.git
     dependencies:
+    - apb
     - axi
     - axi_riscv_atomics
     - cluster_icache
     - common_cells
     - fpnew
     - idma
-    - register_interface
     - riscv-dbg
     - tech_cells_generic
   tech_cells_generic:

--- a/Bender.yml
+++ b/Bender.yml
@@ -10,11 +10,11 @@ package:
 
 dependencies:
   register_interface:       { git: "https://github.com/pulp-platform/register_interface.git", version: 0.4.3  }
-  axi:                      { git: "https://github.com/pulp-platform/axi.git",                version: 0.39.2 }
+  axi:                      { git: https://github.com/colluca/axi,                            rev: multicast }
   cheshire:                 { git: "https://github.com/pulp-platform/cheshire.git",           rev: 586cb0225be5c57f5ffcf67bd490763efd9b4d24}
-  snitch_cluster:           { git: "https://github.com/pulp-platform/snitch_cluster.git",     rev: c12ce9b2af1ac8edf3d4feb18939e1ad20c42225}
+  snitch_cluster:           { git: "https://github.com/pulp-platform/snitch_cluster.git",     rev: 5b2fccd96c42812774c20ab2f9b811e164809789}
   common_cells:             { git: "https://github.com/pulp-platform/common_cells.git",       version: 1.31.1}
-  idma:                     { git: "https://github.com/pulp-platform/iDMA.git",               rev: 9edf489f57389dce5e71252c79e337f527d3aded}
+  idma:                     { git: "https://github.com/pulp-platform/iDMA.git",               version: 0.6.5 }
   memory_island:            { git: "https://github.com/pulp-platform/memory_island.git",      rev: 64828cb7a9ccc1f1656ec92d06129072f445c319 } # main branch
   apb:                      { git: "https://github.com/pulp-platform/apb.git",                version: 0.2.4          }
   hyperbus:                 { git: "https://github.com/pulp-platform/hyperbus.git",           rev: aottaviano/nonfree } # TMP: to fix hyperbus model issue

--- a/Makefile
+++ b/Makefile
@@ -51,12 +51,14 @@ dvt_flist:
 	mkdir -p .dvt
 	$(BENDER) script flist-plus $(COMMON_TARGS) $(SIM_TARGS) > .dvt/default.build
 
-python-venv: .venv
+python-venv: .venv ## Create a Python virtual environment
 .venv:
 	$(BASE_PYTHON) -m venv $@
 	. $@/bin/activate && \
-	python -m pip install --upgrade pip setuptools && \
-	python -m pip install --cache-dir $(PIP_CACHE_DIR) -r requirements.txt
+	python -m pip install --cache-dir $(PIP_CACHE_DIR) .
+
+python-venv-clean: ## Clean Python virtual environment
+	rm -rf .venv
 
 #################
 # Documentation #

--- a/Makefile
+++ b/Makefile
@@ -16,16 +16,20 @@ VERIBLE_VERILOG_FORMAT ?= $(CHIM_UTILS_DIR)/verible-verilog/verible-verilog-form
 # This avoids running `bender checkout` at every make command
 ifeq ($(shell test -d $(CHIM_ROOT)/.bender || echo 1),)
 CHS_ROOT    ?= $(shell $(BENDER) path cheshire)
-SNITCH_ROOT ?= $(shell $(BENDER) path snitch_cluster)
+SN_ROOT 		?= $(shell $(BENDER) path snitch_cluster)
 IDMA_ROOT   ?= $(shell $(BENDER) path idma)
 HYPERB_ROOT ?= $(shell $(BENDER) path hyperbus)
 endif
 
 # Fall back to safe defaults if dependencies are not cloned yet
 CHS_ROOT    ?= .
-SNITCH_ROOT ?= .
+SN_ROOT ?= .
 IDMA_ROOT   ?= .
 HYPERB_ROOT ?= .
+
+# Use the default snitch cluster cfg. For the moment chimera
+# does not use the snitch_cluster_wrapper feature but we need to generate some files.
+SN_CFG = $(SN_ROOT)/cfg/default.json
 
 # Bender prerequisites
 BENDER_YML = $(CHIM_ROOT)/Bender.yml

--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ make chim-all
 ```
 Or for more selective builds:
 ```sh
-make chw-hw-init
-make snitch-hw-init
+make chs-hw-init
+make sn-hw-all
 make chim-sw
 make chim-bootrom-init
 ```

--- a/chimera.mk
+++ b/chimera.mk
@@ -90,7 +90,7 @@ TB_DUT = tb_chimera_soc
 #################################
 # Phonies for the entire system #
 #################################
-CHIM_HW_ALL = chs-hw-init snitch-hw-init chim-bootrom-init chs-sim-all
+CHIM_HW_ALL = chs-hw-init chim-bootrom-init chs-sim-all
 CHIM_SW_ALL = chim-sw
 CHIM_ALL += $(CHIM_HW_ALL) $(CHIM_SW_ALL) chim-sim
 CHIM_CLEAN += chim-sw-clean chim-sim-clean

--- a/chimera.mk
+++ b/chimera.mk
@@ -30,10 +30,10 @@ chs-hw-init: update_plic gen_idma_hw $(CHIM_SW_LIB) ## Generate Cheshire RTL
 # Snitch Cluster #
 ##################
 
-include $(SN_ROOT)/make/common.mk
+-include $(SN_ROOT)/make/common.mk
 # Use the snitch toolchain to generate the cluster bootrom
-include $(SN_ROOT)/sw/toolchain.mk
-include $(SN_ROOT)/make/rtl.mk
+-include $(SN_ROOT)/sw/toolchain.mk
+-include $(SN_ROOT)/make/rtl.mk
 
 # .PHONY: snitch-hw-init
 .PHONY: sn-hw-clean sn-hw-all

--- a/chimera.mk
+++ b/chimera.mk
@@ -26,9 +26,23 @@ CHS_SW_LD_DIR = $(CHIM_ROOT)/sw/link
 chs-hw-init: update_plic gen_idma_hw $(CHIM_SW_LIB) ## Generate Cheshire RTL
 	make -B chs-hw-all CHS_XLEN=$(CHS_XLEN) CHS_SW_LD_DIR=$(CHS_SW_LD_DIR)
 
-.PHONY: snitch-hw-init
-snitch-hw-init: ## Generate Snitch RTL
-	make -C $(SNITCH_ROOT) vsim
+##################
+# Snitch Cluster #
+##################
+
+include $(SN_ROOT)/make/common.mk
+# Use the snitch toolchain to generate the cluster bootrom
+include $(SN_ROOT)/sw/toolchain.mk
+include $(SN_ROOT)/make/rtl.mk
+
+# .PHONY: snitch-hw-init
+.PHONY: sn-hw-clean sn-hw-all
+
+sn-hw-all: sn-rtl ## Generate Snitch RTL
+sn-hw-clean: sn-clean-rtl  ## Clean Snitch RTL
+
+# snitch-hw-init: ## Generate Snitch RTL
+# 	make -C $(SN_ROOT) vsim
 
 .PHONY: $(CHIM_SW_DIR)/include/regs/soc_ctrl.h
 $(CHIM_SW_DIR)/include/regs/soc_ctrl.h: $(CHIM_ROOT)/hw/regs/chimera_regs.hjson
@@ -90,7 +104,7 @@ TB_DUT = tb_chimera_soc
 #################################
 # Phonies for the entire system #
 #################################
-CHIM_HW_ALL = chs-hw-init chim-bootrom-init chs-sim-all
+CHIM_HW_ALL = chs-hw-init sn-hw-all chim-bootrom-init chs-sim-all
 CHIM_SW_ALL = chim-sw
 CHIM_ALL += $(CHIM_HW_ALL) $(CHIM_SW_ALL) chim-sim
 CHIM_CLEAN += chim-sw-clean chim-sim-clean

--- a/chimera.mk
+++ b/chimera.mk
@@ -6,9 +6,9 @@
 # Lorenzo Leone <lleone@iis.ee.ethz.ch>
 
 
-CLINTCORES = 46
-PLICCORES = 92
-PLIC_NUM_INTRS = 92
+CLINTCORES = 46     # 1 + tot. #cores (e.g. 5 clusters * 9 cores + 1 = 46)
+PLICCORES = 92      # 2 + 2 * tot. #cores (e.g. 2 * 5 clusters * 9 cores + 2 = 92)
+PLIC_NUM_INTRS = 59 # 58 + ChsCfg.NumExtInIntrs + 1
 
 
 .PHONY: update_plic
@@ -28,7 +28,7 @@ chs-hw-init: update_plic gen_idma_hw $(CHIM_SW_LIB) ## Generate Cheshire RTL
 
 .PHONY: snitch-hw-init
 snitch-hw-init: ## Generate Snitch RTL
-	make -C $(SNITCH_ROOT)/target/snitch_cluster bin/snitch_cluster.vsim
+	make -C $(SNITCH_ROOT) vsim
 
 .PHONY: $(CHIM_SW_DIR)/include/regs/soc_ctrl.h
 $(CHIM_SW_DIR)/include/regs/soc_ctrl.h: $(CHIM_ROOT)/hw/regs/chimera_regs.hjson

--- a/chimera.mk
+++ b/chimera.mk
@@ -41,9 +41,6 @@ chs-hw-init: update_plic gen_idma_hw $(CHIM_SW_LIB) ## Generate Cheshire RTL
 sn-hw-all: sn-rtl ## Generate Snitch RTL
 sn-hw-clean: sn-clean-rtl  ## Clean Snitch RTL
 
-# snitch-hw-init: ## Generate Snitch RTL
-# 	make -C $(SN_ROOT) vsim
-
 .PHONY: $(CHIM_SW_DIR)/include/regs/soc_ctrl.h
 $(CHIM_SW_DIR)/include/regs/soc_ctrl.h: $(CHIM_ROOT)/hw/regs/chimera_regs.hjson
 	python $(CHIM_ROOT)/utils/reggen/regtool.py -D $<  > $@
@@ -104,10 +101,11 @@ TB_DUT = tb_chimera_soc
 #################################
 # Phonies for the entire system #
 #################################
-CHIM_HW_ALL = chs-hw-init sn-hw-all chim-bootrom-init chs-sim-all
+CHIM_HW_ALL = chs-hw-init sn-hw-all chim-bootrom-init
 CHIM_SW_ALL = chim-sw
-CHIM_ALL += $(CHIM_HW_ALL) $(CHIM_SW_ALL) chim-sim
-CHIM_CLEAN += chim-sw-clean chim-sim-clean
+CHIM_SIM_ALL = chim-sim
+CHIM_ALL += $(CHIM_HW_ALL) $(CHIM_SW_ALL) $(CHIM_SIM_ALL)
+CHIM_CLEAN += chim-sw-clean chim-sim-clean sn-hw-clean
 
 .PHONY: chim-all
 chim-all: $(CHIM_ALL) ## Generate full chimera infrastructure

--- a/hw/chimera_pkg.sv
+++ b/hw/chimera_pkg.sv
@@ -149,12 +149,6 @@ ExtClusters
   localparam int unsigned LogDepth = 3;
   localparam int unsigned SyncStages = 3;
 
-  // ------------
-  // |   TCDM   |
-  // ------------
-  localparam doub_bt TcdmSize = 128;
-  localparam aw_bt TcdmAddrWidth = $clog2(TcdmSize * 1024);
-
   // -------------------
   // |   Generate Cfg   |
   // --------------------

--- a/hw/chimera_pkg.sv
+++ b/hw/chimera_pkg.sv
@@ -127,6 +127,8 @@ ExtClusters
   localparam doub_bt MemIslRegionStart = 64'h4800_0000;
   localparam doub_bt MemIslRegionEnd = 64'h4804_0000;
 
+  // Size of memory island: MemIslNumWideBanks * MemIslNarrowToWideFactor * MemIslWordsPerBank * <BytesPerWord>
+  // with BytesPerWord = cfg.AxiDataWidth / 8
   localparam aw_bt MemIslAxiMstIdWidth = 1;
   localparam byte_bt MemIslNarrowToWideFactor = 16;
   localparam byte_bt MemIslNarrowPorts = 1;
@@ -146,6 +148,12 @@ ExtClusters
 
   localparam int unsigned LogDepth = 3;
   localparam int unsigned SyncStages = 3;
+
+  // ------------
+  // |   TCDM   |
+  // ------------
+  localparam doub_bt TcdmSize = 128;
+  localparam aw_bt TcdmAddrWidth = $clog2(TcdmSize * 1024);
 
   // -------------------
   // |   Generate Cfg   |
@@ -174,7 +182,7 @@ ExtClusters
     // AXI CFG
     cfg.AxiMstIdWidth = 2;
     cfg.AxiDataWidth = 32;
-    cfg.AddrWidth = 32;
+    cfg.AddrWidth = 48;
     cfg.LlcOutRegionEnd = 'hFFFF_FFFF;
 
     cfg.AxiExtNumWideMst = $countones(ChimeraClusterCfg.hasWideMasterPort);

--- a/hw/clusters/chimera_cluster.sv
+++ b/hw/clusters/chimera_cluster.sv
@@ -220,6 +220,12 @@ module chimera_cluster
   localparam int unsigned NumIntOutstandingLoads[NrCores] = '{NrCores{32'h1}};
   localparam int unsigned NumIntOutstandingMem[NrCores] = '{NrCores{32'h4}};
 
+
+  // ----------------
+  // |   TCDM INTF   |
+  // ----------------
+  localparam int unsigned TcdmSize = 128;
+  localparam aw_bt TcdmAddrWidth = $clog2(TcdmSize * 1024);
   typedef logic [WideDataWidth-1:0] data_dma_t;
   typedef logic [WideDataWidth/8-1:0] strb_dma_t;
   typedef logic [TcdmAddrWidth-1:0] tcdm_addr_t;

--- a/hw/clusters/chimera_cluster.sv
+++ b/hw/clusters/chimera_cluster.sv
@@ -51,6 +51,7 @@ module chimera_cluster
 );
 
   `include "axi/typedef.svh"
+  `include "tcdm_interface/typedef.svh"
 
   localparam int WideDataWidth = $bits(wide_out_req_o.w.data);
 
@@ -219,6 +220,11 @@ module chimera_cluster
   localparam int unsigned NumIntOutstandingLoads[NrCores] = '{NrCores{32'h1}};
   localparam int unsigned NumIntOutstandingMem[NrCores] = '{NrCores{32'h4}};
 
+  typedef logic [WideDataWidth-1:0] data_dma_t;
+  typedef logic [WideDataWidth/8-1:0] strb_dma_t;
+  typedef logic [TcdmAddrWidth-1:0] tcdm_addr_t;
+  `TCDM_TYPEDEF_ALL(tcdm_dma, tcdm_addr_t, data_dma_t, strb_dma_t, logic)
+
   snitch_cluster #(
     .PhysicalAddrWidth(Cfg.ChsCfg.AddrWidth),
     .NarrowDataWidth  (ClusterDataWidth),            // SCHEREMO: Convolve needs this...
@@ -228,7 +234,8 @@ module chimera_cluster
     .NarrowUserWidth  (Cfg.ChsCfg.AxiUserWidth),
     .WideUserWidth    (Cfg.ChsCfg.AxiUserWidth),
 
-    .BootAddr(SnitchBootROMRegionStart),
+    .BootAddr        (SnitchBootROMRegionStart),
+    .IntBootromEnable(0),
 
     .NrHives          (1),
     .NrCores          (NrCores),
@@ -242,7 +249,7 @@ module chimera_cluster
 
     .ICacheLineWidth('{256}),
     .ICacheLineCount('{16}),
-    .ICacheSets     ('{2}),
+    .ICacheWays     ('{2}),
 
     .VMSupport(0),
     .Xdma     ({1'b1, {(NrCores - 1) {1'b0}}}),
@@ -263,6 +270,8 @@ module chimera_cluster
     .narrow_out_resp_t(axi_cluster_out_narrow_resp_t),
     .wide_out_req_t   (axi_cluster_out_wide_req_t),
     .wide_out_resp_t  (axi_cluster_out_wide_resp_t),
+    .tcdm_dma_req_t   (tcdm_dma_req_t),
+    .tcdm_dma_rsp_t   (tcdm_dma_rsp_t),
 
     .sram_cfg_t (sram_cfg_t),
     .sram_cfgs_t(sram_cfgs_t),
@@ -279,6 +288,7 @@ module chimera_cluster
     .meip_i     (meip_i),
     .mtip_i     (mtip_i),
     .msip_i     (msip_i),
+    .mxip_i     ('0),
 
     .hart_base_id_i     (hart_base_id_i),
     .cluster_base_addr_i(cluster_base_addr_i),
@@ -291,7 +301,12 @@ module chimera_cluster
     .wide_in_req_i    ('0),
     .wide_in_resp_o   (),
     .wide_out_req_o   (clu_axi_wide_mst_req),
-    .wide_out_resp_i  (clu_axi_wide_mst_resp)
+    .wide_out_resp_i  (clu_axi_wide_mst_resp),
+
+    .narrow_ext_req_o (),
+    .narrow_ext_resp_i('0),
+    .tcdm_ext_req_i   ('0),
+    .tcdm_ext_resp_o  ()
 
   );
 endmodule

--- a/hw/rv_plic.cfg.hjson
+++ b/hw/rv_plic.cfg.hjson
@@ -7,8 +7,8 @@
 {
     instance_name: "rv_plic",
     param_values: {
-        src: 92,
-        target: 92,
+        src: 59 ,
+        target: 92      ,
         prio: 7,
         nonstd_regs: 0  // Do *not* include these: MSIPs are not used and we use a 64 MiB address space
     },

--- a/iis-env.sh
+++ b/iis-env.sh
@@ -13,7 +13,13 @@ export RISCV_GCC_BINROOT=/usr/pack/riscv-1.0-kgf/pulp-gcc-2.5.0/bin
 export CC=/usr/pack/gcc-11.2.0-af/linux-x64/bin/gcc
 export CXX=/usr/pack/gcc-11.2.0-af/linux-x64/bin/g++
 export CMAKE=cmake-3.28.3
+<<<<<<< HEAD
 export SN_LLVM_BINROOT=/usr/scratch2/vulcano/colluca/tools/riscv32-snitch-llvm-almalinux8-15.0.0-snitch-0.2.0/bin
+||||||| parent of 100d55f (Introduce pyproject)
+=======
+export BENDER='bender-0.28.1'
+export SNRT_BENDER='bender-0.28.1'
+>>>>>>> 100d55f (Introduce pyproject)
 
 # Create the python venv
 if [ ! -d ".venv" ]; then

--- a/iis-env.sh
+++ b/iis-env.sh
@@ -13,6 +13,7 @@ export RISCV_GCC_BINROOT=/usr/pack/riscv-1.0-kgf/pulp-gcc-2.5.0/bin
 export CC=/usr/pack/gcc-11.2.0-af/linux-x64/bin/gcc
 export CXX=/usr/pack/gcc-11.2.0-af/linux-x64/bin/g++
 export CMAKE=cmake-3.28.3
+export SN_LLVM_BINROOT=/usr/scratch2/vulcano/colluca/tools/riscv32-snitch-llvm-almalinux8-15.0.0-snitch-0.2.0/bin
 
 # Create the python venv
 if [ ! -d ".venv" ]; then

--- a/iis-env.sh
+++ b/iis-env.sh
@@ -14,7 +14,6 @@ export CXX=/usr/pack/gcc-11.2.0-af/linux-x64/bin/g++
 export CMAKE=cmake-3.28.3
 export SN_LLVM_BINROOT=/usr/scratch2/vulcano/colluca/tools/riscv32-snitch-llvm-almalinux8-15.0.0-snitch-0.2.0/bin
 export BENDER='bender-0.29.1'
-export SNRT_BENDER='bender-0.29.1'
 
 # Create the python venv
 if [ ! -d ".venv" ]; then

--- a/iis-env.sh
+++ b/iis-env.sh
@@ -8,18 +8,13 @@ export VOPT="questa-2022.3 vopt"
 export VLIB="questa-2022.3 vlib"
 export BASE_PYTHON=/usr/local/anaconda3/bin/python3.11
 export CHS_SW_GCC_BINROOT=/usr/pack/riscv-1.0-kgf/riscv64-gcc-12.2.0/bin
-export LLVM_BINROOT=/usr/scratch2/vulcano/colluca/tools/riscv32-snitch-llvm-almalinux8-15.0.0-snitch-0.2.0/bin
 export RISCV_GCC_BINROOT=/usr/pack/riscv-1.0-kgf/pulp-gcc-2.5.0/bin
 export CC=/usr/pack/gcc-11.2.0-af/linux-x64/bin/gcc
 export CXX=/usr/pack/gcc-11.2.0-af/linux-x64/bin/g++
 export CMAKE=cmake-3.28.3
-<<<<<<< HEAD
 export SN_LLVM_BINROOT=/usr/scratch2/vulcano/colluca/tools/riscv32-snitch-llvm-almalinux8-15.0.0-snitch-0.2.0/bin
-||||||| parent of 100d55f (Introduce pyproject)
-=======
-export BENDER='bender-0.28.1'
-export SNRT_BENDER='bender-0.28.1'
->>>>>>> 100d55f (Introduce pyproject)
+export BENDER='bender-0.29.1'
+export SNRT_BENDER='bender-0.29.1'
 
 # Create the python venv
 if [ ! -d ".venv" ]; then

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
   "flatdict",
   "json5",
   "peakrdl",
-  "peakrdl-rawheader @ git+https://github.com/colluca/PeakRDL-rawheader.git@7b8dbc9ad5854dc1cdaf36d4ea024c29ffb00a4c",
+  "peakrdl-rawheader",
   "peakrdl-markdown",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,30 @@
+# Copyright 2023 ETH Zurich and University of Bologna.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+[build-system]
+requires = ["setuptools<81", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "chimera"
+version = "0.0.0"
+description = "A Flexible Multi-Accelerator Framework for Heterogeneous SoC Integration"
+readme = "README.md"
+requires-python = ">=3.11"
+authors = [{ name = "Lorenzo Leone", email = "lleone@iis.ee.ethz.ch" }]
+
+dependencies = [
+  "hjson",
+  "tabulate",
+  "pyyaml",
+  "mako",
+  "jsonref",
+  "jsonschema",
+  "flatdict",
+  "setuptools==65.5.1",
+]
+
+[tool.setuptools]
+packages = []
+include-package-data = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,10 @@ dependencies = [
   "jsonref",
   "jsonschema",
   "flatdict",
-  "json5"
+  "json5",
+  "peakrdl",
+  "peakrdl-rawheader @ git+https://github.com/colluca/PeakRDL-rawheader.git@7b8dbc9ad5854dc1cdaf36d4ea024c29ffb00a4c",
+  "peakrdl-markdown",
 ]
 
 [tool.setuptools]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,12 +3,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [build-system]
-requires = ["setuptools<81", "wheel"]
+requires = ["setuptools==68.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "chimera"
-version = "0.0.0"
+version = "1.0.0"
 description = "A Flexible Multi-Accelerator Framework for Heterogeneous SoC Integration"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -22,7 +22,7 @@ dependencies = [
   "jsonref",
   "jsonschema",
   "flatdict",
-  "setuptools==65.5.1",
+  "json5"
 ]
 
 [tool.setuptools]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,0 @@
-hjson
-tabulate
-pyyaml
-mako
-jsonref
-jsonschema
-flatdict
-json5
-peakrdl-rawheader@git+https://github.com/colluca/PeakRDL-rawheader.git@7b8dbc9ad5854dc1cdaf36d4ea024c29ffb00a4c

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ mako
 jsonref
 jsonschema
 flatdict
+json5
+peakrdl-rawheader@git+https://github.com/colluca/PeakRDL-rawheader.git@7b8dbc9ad5854dc1cdaf36d4ea024c29ffb00a4c

--- a/target/sim/sim.mk
+++ b/target/sim/sim.mk
@@ -61,7 +61,7 @@ HYP0_PRELOAD_MEM_FILE ?= ""
 
 # Generate vsim compilation script
 $(CHIM_SIM_DIR)/vsim/compile.tcl: $(BENDER_YML) $(BENDER_LOCK)
-	@bender script vsim $(SIM_TARGS) --vlog-arg="$(CHIM_VLOG_ARGS)" > $@
+	bender script vsim $(SIM_TARGS) --vlog-arg="$(CHIM_VLOG_ARGS)" > $@
 	echo 'vlog -work $(VSIM_WORK) "$(realpath $(CHS_ROOT))/target/sim/src/elfloader.cpp" -ccflags "-std=c++11"' >> $@
 
 # Compiler the design

--- a/target/sim/sim.mk
+++ b/target/sim/sim.mk
@@ -46,8 +46,7 @@ $(eval $(call add_vsim_flag,IMAGE))
 .PHONY: chim-sim chim-compile chim-run chim-run-batch
 chim-sim: chim-hyperram-model chim-compile $(CHIM_ALL) ## Compile Chimera SoC
 
-# Get HyperRAM verification IP (VIP) for simulation
-.PHONY: chim-hyperram-model
+.PHONY: chim-hyperram-model ## Get HypperRAM VIP for simulation
 chim-hyperram-model: $(CHIM_SIM_DIR)/models/s27ks0641/s27ks0641.sv
 $(CHIM_SIM_DIR)/models/s27ks0641/s27ks0641.sv:
 	make -C $(HYPERB_ROOT) models/s27ks0641
@@ -61,7 +60,7 @@ HYP0_PRELOAD_MEM_FILE ?= ""
 
 # Generate vsim compilation script
 $(CHIM_SIM_DIR)/vsim/compile.tcl: $(BENDER_YML) $(BENDER_LOCK)
-	bender script vsim $(SIM_TARGS) --vlog-arg="$(CHIM_VLOG_ARGS)" > $@
+	$(BENDER) script vsim $(SIM_TARGS) --vlog-arg="$(CHIM_VLOG_ARGS)" > $@
 	echo 'vlog -work $(VSIM_WORK) "$(realpath $(CHS_ROOT))/target/sim/src/elfloader.cpp" -ccflags "-std=c++11"' >> $@
 
 # Compiler the design

--- a/target/sim/sim.mk
+++ b/target/sim/sim.mk
@@ -44,7 +44,7 @@ $(eval $(call add_vsim_flag,IMAGE))
 
 # Init vsim compilation
 .PHONY: chim-sim chim-compile chim-run chim-run-batch
-chim-sim: chim-hyperram-model chim-compile $(CHIM_ALL) ## Compile Chimera SoC
+chim-sim: chim-hyperram-model chs-sim-all chim-compile ## Compile Chimera SoC
 
 .PHONY: chim-hyperram-model ## Get HypperRAM VIP for simulation
 chim-hyperram-model: $(CHIM_SIM_DIR)/models/s27ks0641/s27ks0641.sv

--- a/target/sim/src/fixture_chimera_soc.sv
+++ b/target/sim/src/fixture_chimera_soc.sv
@@ -130,6 +130,8 @@ module fixture_chimera_soc #(
     .hyper_dq_o               (hyper_dq_o),
     .hyper_dq_oe_o            (hyper_dq_oe_o),
     .hyper_reset_no           (hyper_reset_no),
+    .apb_req_o                (),
+    .apb_rsp_i                ('0),
     .pmu_rst_clusters_ni      ({ExtClusters{rst_n}}),
     .pmu_clkgate_en_clusters_i(),
     .pmu_iso_en_clusters_i    ('0),                    // Never Isolate


### PR DESCRIPTION
# Bump Snitch Cluster

This PR bumps the Snitch cluster, following the update performed in [#81](https://github.com/pulp-platform/chimera/pull/81) (@Paolo309).

It also updates the integration of the Snitch cluster within the top-level make flow.

## Main Changes

### Dependencies
- Updated `Bender.yml` and corresponding `.lock` files to align with upstream dependencies.
- Notable change: switched `axi` to https://github.com/colluca/axi (branch `multicast`).

### `chimera_cluster.sv`
- Added a TCDM interface (currently left unconnected).

### Make flow
- Renamed `snitch-hw-init` to `sn-hw-all`, consistent with the upstream Snitch cluster [documentation](https://pulp-platform.github.io/snitch_cluster/ug/system_integration.html#generating-the-rtl).
- Integrated the `chs-sim-all` target into `chim-sim`.

### Python environment
- Added a `pyproject.toml` file to manage Python dependencies.
- Fixed the Bender version in `iis-env` to `0.29.1`.
